### PR TITLE
Russian translation added.

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -44,11 +44,13 @@ Currently Solaar has been translated in the following languages:
 - Polski: [Adrian Piotrowicz][nexces]
 - Portuguese-BR: [Drovetto][drovetto], [Josenivaldo Benito Jr.][jrbenito]
 - Română: Daniel Pavel
+- Russian: [Dimitriy Ryazantcev][DJm00n]
 - Svensk: [Daniel Zippert][zipperten], Emelie Snecker
 
 [papoteur]: http://github.com/papoteur
 [david-geiger]: http://github.com/david-geiger
 [damsweb]: http://github.com/damsweb
+[DJm00n]: https://github.com/DJm00n
 [nexces]: http://github.com/nexces
 [zipperten]: http://github.com/zipperten
 [micheleolivo]: http://github.com/micheleolivo

--- a/lib/logitech_receiver/i18n.py
+++ b/lib/logitech_receiver/i18n.py
@@ -38,7 +38,7 @@ _DUMMY = (
 		_("empty"), _("critical"), _("low"), _("good"), _("full"),
 
 		# battery charging statuses
-		_("discharging"), _("recharging"), _("almost full"), _("full"),
+		_("discharging"), _("recharging"), _("almost full"), _("charged"),
 		_("slow recharge"), _("invalid battery"), _("thermal error"),
 
 		# pairing errors

--- a/lib/logitech_receiver/notifications.py
+++ b/lib/logitech_receiver/notifications.py
@@ -64,7 +64,7 @@ def _process_receiver_notification(receiver, status, n):
 	# pairing lock notification
 	if n.sub_id == 0x4A:
 		status.lock_open = bool(n.address & 0x01)
-		reason = _("pairing lock is ") + (_("open") if status.lock_open else _("closed"))
+		reason = (_("pairing lock is open") if status.lock_open else _("pairing lock is closed"))
 		if _log.isEnabledFor(_INFO):
 			_log.info("%s: %s", receiver, reason)
 

--- a/lib/logitech_receiver/status.py
+++ b/lib/logitech_receiver/status.py
@@ -27,6 +27,7 @@ del getLogger
 
 
 from .i18n import _
+from gettext import ngettext
 from .common import NamedInts as _NamedInts, NamedInt as _NamedInt
 from . import hidpp10 as _hidpp10
 from . import hidpp20 as _hidpp20
@@ -96,8 +97,7 @@ class ReceiverStatus(dict):
 	def __str__(self):
 		count = len(self._receiver)
 		return (_("No paired devices.") if count == 0 else
-				_("1 paired device.") if count == 1 else
-				(str(count) + _(" paired devices.")))
+			ngettext("%(count)s paired device.", "%(count)s paired devices.", count) % { 'count': count })
 	__unicode__ = __str__
 
 	def changed(self, alert=ALERT.NOTIFICATION, reason=None):
@@ -146,9 +146,9 @@ class DeviceStatus(dict):
 			battery_level = self.get(KEYS.BATTERY_LEVEL)
 			if battery_level is not None:
 				if isinstance(battery_level, _NamedInt):
-					yield _("Battery") + ': ' + _(str(battery_level))
+					yield _("Battery: %(level)s") % { 'level': _(str(battery_level)) }
 				else:
-					yield _("Battery") + ': ' + ('%d%%' % battery_level)
+					yield _("Battery: %(percent)d%%") % { 'percent': battery_level }
 
 				battery_status = self.get(KEYS.BATTERY_STATUS)
 				if battery_status is not None:
@@ -159,7 +159,7 @@ class DeviceStatus(dict):
 			light_level = self.get(KEYS.LIGHT_LEVEL)
 			if light_level is not None:
 				if comma: yield ', '
-				yield _("Lighting") + (': %d ' % light_level) + _("lux")
+				yield _("Lighting: %(level)s lux") % { 'level': light_level }
 
 		return ''.join(i for i in _items())
 
@@ -200,9 +200,9 @@ class DeviceStatus(dict):
 				# only show the notification once
 				alert = ALERT.NOTIFICATION | ALERT.ATTENTION
 			if isinstance(level, _NamedInt):
-				reason = '%s: %s (%s)' % (_("Battery"), _(str(level)), _(str(status)))
+				reason = _("Battery: %(level)s (%(status)s)") % { 'level': _(level), 'status': _(status) }
 			else:
-				reason = '%s: %d%% (%s)' % (_("Battery"), level, _(str(status)))
+				reason = _("Battery: %(percent)d%% (%(status)s)") % { 'percent': level, 'status': _(status) }
 
 		if changed or reason:
 			# update the leds on the device, if any

--- a/lib/solaar/ui/about.py
+++ b/lib/solaar/ui/about.py
@@ -72,6 +72,7 @@ def _create():
 					'Drovetto, JrBenito (Portuguese-BR)',
 					'Daniel Pavel (română)',
 					'Daniel Zippert, Emelie Snecker (svensk)',
+					'Dimitriy Ryazantcev (Russian)',
 					)))
 
 	about.set_website('http://pwr.github.io/Solaar/')

--- a/lib/solaar/ui/pair_window.py
+++ b/lib/solaar/ui/pair_window.py
@@ -152,7 +152,7 @@ def _pairing_succeeded(assistant, receiver, device):
 
 	page = _create_page(assistant, Gtk.AssistantPageType.SUMMARY)
 
-	header = Gtk.Label(_("Found a new device") + ':')
+	header = Gtk.Label(_("Found a new device:"))
 	header.set_alignment(0.5, 0)
 	page.pack_start(header, False, False, 0)
 
@@ -194,7 +194,7 @@ def create(receiver):
 	assert receiver.kind is None
 
 	assistant = Gtk.Assistant()
-	assistant.set_title(receiver.name + ': ' + _("pair new device"))
+	assistant.set_title(_('%(receiver_name)s: pair new device') % { 'receiver_name': receiver.name })
 	assistant.set_icon_name('list-add')
 
 	assistant.set_size_request(400, 240)

--- a/po/ru.po
+++ b/po/ru.po
@@ -1,0 +1,510 @@
+# Russian translations for solaar package.
+# Copyright (C) 2013 THE solaar'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the solaar package.
+#
+# Automatically generated, 2013.
+# Dmitry Ryazantcev <DJm00n@mail.ru>, 2013-2016.
+msgid   ""
+msgstr  "Project-Id-Version: solaar 0.9.2\n"
+        "Report-Msgid-Bugs-To: \n"
+        "POT-Creation-Date: 2016-12-21 00:13+0200\n"
+        "PO-Revision-Date: 2016-12-21 00:12+0200\n"
+        "Last-Translator: Dmitry Ryazantcev <DJm00n@mail.ru>\n"
+        "Language-Team: Russian <git@vger.kernel.org>\n"
+        "Language: ru\n"
+        "MIME-Version: 1.0\n"
+        "Content-Type: text/plain; charset=UTF-8\n"
+        "Content-Transfer-Encoding: 8bit\n"
+        "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 "
+        "&& n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+        "X-Generator: Poedit 1.5.4\n"
+
+#: lib/logitech_receiver/i18n.py:38
+msgid   "critical"
+msgstr  "критический"
+
+#: lib/logitech_receiver/i18n.py:38
+msgid   "empty"
+msgstr  "пусто"
+
+#: lib/logitech_receiver/i18n.py:38
+msgid   "full"
+msgstr  "полный"
+
+#: lib/logitech_receiver/i18n.py:38
+msgid   "good"
+msgstr  "средний"
+
+#: lib/logitech_receiver/i18n.py:38
+msgid   "low"
+msgstr  "низкий"
+
+#: lib/logitech_receiver/i18n.py:41
+msgid   "almost full"
+msgstr  "почти полная"
+
+#: lib/logitech_receiver/i18n.py:41
+msgid   "charged"
+msgstr  "заряжено"
+
+#: lib/logitech_receiver/i18n.py:41
+msgid   "discharging"
+msgstr  "разряжается"
+
+#: lib/logitech_receiver/i18n.py:41
+msgid   "recharging"
+msgstr  "перезаряжается"
+
+#: lib/logitech_receiver/i18n.py:42
+msgid   "invalid battery"
+msgstr  "недопустимая батарея"
+
+#: lib/logitech_receiver/i18n.py:42
+msgid   "slow recharge"
+msgstr  "медленная разрядка"
+
+#: lib/logitech_receiver/i18n.py:42
+msgid   "thermal error"
+msgstr  "тепловая ошибка"
+
+#: lib/logitech_receiver/i18n.py:45
+msgid   "device not supported"
+msgstr  "устройство не поддерживается"
+
+#: lib/logitech_receiver/i18n.py:45
+msgid   "device timeout"
+msgstr  "тайм аут устройства"
+
+#: lib/logitech_receiver/i18n.py:45
+msgid   "sequence timeout"
+msgstr  "тайм аут последовательности"
+
+#: lib/logitech_receiver/i18n.py:45
+msgid   "too many devices"
+msgstr  "слишком много устройств"
+
+#: lib/logitech_receiver/i18n.py:48
+msgid   "Bootloader"
+msgstr  "Загрузчик"
+
+#: lib/logitech_receiver/i18n.py:48 lib/solaar/ui/window.py:525
+msgid   "Firmware"
+msgstr  "Прошивка"
+
+#: lib/logitech_receiver/i18n.py:48
+msgid   "Hardware"
+msgstr  "Оборудование"
+
+#: lib/logitech_receiver/i18n.py:48
+msgid   "Other"
+msgstr  "Другое"
+
+#: lib/logitech_receiver/notifications.py:67
+msgid   "pairing lock is closed"
+msgstr  "сопряжение заблокировано"
+
+#: lib/logitech_receiver/notifications.py:67
+msgid   "pairing lock is open"
+msgstr  "сопряжение разблокировано"
+
+#: lib/logitech_receiver/notifications.py:150 lib/solaar/ui/notify.py:123
+msgid   "unpaired"
+msgstr  "не сопряжено"
+
+#: lib/logitech_receiver/notifications.py:192
+msgid   "powered on"
+msgstr  "включено"
+
+#: lib/logitech_receiver/receiver.py:107 lib/solaar/ui/window.py:611
+msgid   "unknown"
+msgstr  "неизвестно"
+
+#: lib/logitech_receiver/settings_templates.py:119
+msgid   "Smooth Scrolling"
+msgstr  "Плавная прокрутка"
+
+#: lib/logitech_receiver/settings_templates.py:120
+msgid   "High-sensitivity mode for vertical scroll with the wheel."
+msgstr  "Режим высокой чувствительности для вертикальной прокрутки колесом."
+
+#: lib/logitech_receiver/settings_templates.py:121
+msgid   "Side Scrolling"
+msgstr  "Горизонтальная прокрутка"
+
+#: lib/logitech_receiver/settings_templates.py:122
+msgid   "When disabled, pushing the wheel sideways sends custom button "
+        "events\n"
+        "instead of the standard side-scrolling events."
+msgstr  "Когда отключено, нажатие на колесо сбоку будет отправлять\n"
+        "пользовательские события нажатия, вместо стандартных\n"
+        "событий горизонтальной прокрутки."
+
+#: lib/logitech_receiver/settings_templates.py:124
+msgid   "Sensitivity (DPI)"
+msgstr  "Чувствительность (DPI)"
+
+#: lib/logitech_receiver/settings_templates.py:125
+msgid   "Swap Fx function"
+msgstr  "Сменить поведение Fx"
+
+#: lib/logitech_receiver/settings_templates.py:126
+msgid   "When set, the F1..F12 keys will activate their special function,\n"
+        "and you must hold the FN key to activate their standard function."
+msgstr  "Если включено,  то кнопки F1..F12 будут активировать\n"
+        "их дополнительную функцию и вы должны будете зажать\n"
+        "кнопку FN для активации их стандартной функции."
+
+#: lib/logitech_receiver/settings_templates.py:129
+msgid   "When unset, the F1..F12 keys will activate their standard function,\n"
+        "and you must hold the FN key to activate their special function."
+msgstr  "Если выключено,  то кнопки F1..F12 будут активировать\n"
+        "их стандартную функцию и вы должны будете зажать\n"
+        "кнопку FN для активации их дополнительной функции."
+
+#: lib/logitech_receiver/settings_templates.py:131
+msgid   "Hand Detection"
+msgstr  "Обнаружение рук"
+
+#: lib/logitech_receiver/settings_templates.py:132
+msgid   "Turn on illumination when the hands hover over the keyboard."
+msgstr  "Включать подсветку, когда руки над клавиатурой."
+
+#: lib/logitech_receiver/settings_templates.py:133
+msgid   "Smart Shift"
+msgstr  "Smart Shift"
+
+#: lib/logitech_receiver/settings_templates.py:134
+msgid   "Automatically switch the mouse wheel between ratchet and freespin "
+        "mode.\n"
+        "The mouse wheel is always free at 0, and always locked at 50"
+msgstr  "Автоматически переключать режим колесика между пошаговой и "
+        "сверхбыстрой прокруткой.\n"
+        "Колесико мыши всегда свободно при значении 0 и заблокировано при 50"
+
+#: lib/logitech_receiver/status.py:99
+msgid   "No paired devices."
+msgstr  "Нет сопряженных устройств."
+
+#: lib/logitech_receiver/status.py:100 lib/solaar/ui/window.py:566
+#, python-format
+msgid   "%(count)s paired device."
+msgid_plural    "%(count)s paired devices."
+msgstr[0]       "%(count)s сопряженное устройство."
+msgstr[1]       "%(count)s сопряженные устройства."
+msgstr[2]       "%(count)s сопряженных устройств."
+
+#: lib/logitech_receiver/status.py:149
+#, python-format
+msgid   "Battery: %(level)s"
+msgstr  "Батарея: %(level)s"
+
+#: lib/logitech_receiver/status.py:151
+#, python-format
+msgid   "Battery: %(percent)d%%"
+msgstr  "Батарея: %(percent)d%%"
+
+#: lib/logitech_receiver/status.py:162
+#, python-format
+msgid   "Lighting: %(level)s lux"
+msgstr  "Освещенность: %(level)s lux"
+
+#: lib/logitech_receiver/status.py:203
+#, python-format
+msgid   "Battery: %(level)s (%(status)s)"
+msgstr  "Батарея: %(level)s (%(status)s)"
+
+#: lib/logitech_receiver/status.py:205
+#, python-format
+msgid   "Battery: %(percent)d%% (%(status)s)"
+msgstr  "Батарея: %(percent)d%% (%(status)s)"
+
+#: lib/solaar/listener.py:95
+msgid   "The receiver was unplugged."
+msgstr  "Приёмник был извлечен."
+
+#: lib/solaar/ui/__init__.py:48
+msgid   "Permissions error"
+msgstr  "Ошибка доступа"
+
+#: lib/solaar/ui/__init__.py:49
+#, python-format
+msgid   "Found a Logitech Receiver (%s), but did not have permission to open "
+        "it."
+msgstr  "Найден приёмник Logitech (%s), но нет прав для доступа к нему."
+
+#: lib/solaar/ui/__init__.py:51
+msgid   "If you've just installed Solaar, try removing the receiver and "
+        "plugging it back in."
+msgstr  "Если это первый запуск Solaar, попробуйте извлечь и снова вставить "
+        "приёмник."
+
+#: lib/solaar/ui/__init__.py:53
+msgid   "Unpairing failed"
+msgstr  "Отмена сопряжения не удалась"
+
+#: lib/solaar/ui/__init__.py:54
+#, python-brace-format
+msgid   "Failed to unpair %{device} from %{receiver}."
+msgstr  "Отмена сопряжения %{device} с %{receiver} не удалась."
+
+#: lib/solaar/ui/__init__.py:56
+msgid   "The receiver returned an error, with no further details."
+msgstr  "Приёмник вернул ошибку, без дополнительных деталей."
+
+#: lib/solaar/ui/about.py:39
+msgid   "Shows status of devices connected\n"
+        "through wireless Logitech receivers."
+msgstr  "Показывает статус устройств, подсоединенных\n"
+        "через беспроводные приёмники Logitech."
+
+#: lib/solaar/ui/about.py:48
+msgid   "GUI design"
+msgstr  "Дизайн интерфейса"
+
+#: lib/solaar/ui/about.py:49
+msgid   "Testing"
+msgstr  "Тестирование"
+
+#: lib/solaar/ui/about.py:54
+msgid   "Logitech documentation"
+msgstr  "Документация Logitech"
+
+#: lib/solaar/ui/action.py:68 lib/solaar/ui/window.py:306
+msgid   "About"
+msgstr  "О программе"
+
+#: lib/solaar/ui/action.py:95 lib/solaar/ui/action.py:98
+#: lib/solaar/ui/window.py:193
+msgid   "Unpair"
+msgstr  "Отмена сопряжения"
+
+#: lib/solaar/ui/config_panel.py:120
+msgid   "Working"
+msgstr  "Работает"
+
+#: lib/solaar/ui/config_panel.py:123
+msgid   "Read/write operation failed."
+msgstr  "Операция чтения/записи не удалась."
+
+#: lib/solaar/ui/notify.py:125
+msgid   "connected"
+msgstr  "соединено"
+
+#: lib/solaar/ui/notify.py:127 lib/solaar/ui/tray.py:295
+#: lib/solaar/ui/tray.py:300 lib/solaar/ui/window.py:647
+msgid   "offline"
+msgstr  "нет соединения"
+
+#: lib/solaar/ui/pair_window.py:133
+msgid   "Pairing failed"
+msgstr  "Сопряжение не удалось"
+
+#: lib/solaar/ui/pair_window.py:135
+msgid   "Make sure your device is within range, and has a decent battery "
+        "charge."
+msgstr  "Удостоверьтесь, что ваше устройство в радиусе приёма и батарея "
+        "заряжена."
+
+#: lib/solaar/ui/pair_window.py:137
+msgid   "A new device was detected, but it is not compatible with this "
+        "receiver."
+msgstr  "Обнаружено новое устройство, но оно не совместимо с этим приёмником."
+
+#: lib/solaar/ui/pair_window.py:139
+#, python-format
+msgid   "The receiver only supports %d paired device(s)."
+msgstr  "Приёмник поддерживает только %d сопряженных устройств(а)."
+
+#: lib/solaar/ui/pair_window.py:141
+msgid   "No further details are available about the error."
+msgstr  "Дополнительные детали об этой ошибке не доступны."
+
+#: lib/solaar/ui/pair_window.py:155
+msgid   "Found a new device:"
+msgstr  "Найдено новое устройство:"
+
+#: lib/solaar/ui/pair_window.py:180
+msgid   "The wireless link is not encrypted"
+msgstr  "Беспроводное соединение не зашифровано"
+
+#: lib/solaar/ui/pair_window.py:197
+#, python-format
+msgid   "%(receiver_name)s: pair new device"
+msgstr  "%(receiver_name)s: новое сопряженное устройство"
+
+#: lib/solaar/ui/pair_window.py:205
+msgid   "Turn on the device you want to pair."
+msgstr  "Включите устройство, с которым вы хотите создать сопряжение."
+
+#: lib/solaar/ui/pair_window.py:206
+msgid   "If the device is already turned on,\n"
+        "turn if off and on again."
+msgstr  "Если устройство уже включено,\n"
+        "выключите и включите его снова."
+
+#: lib/solaar/ui/tray.py:55
+msgid   "No Logitech receiver found"
+msgstr  "Приёмник Logitech не найден"
+
+#: lib/solaar/ui/tray.py:62
+msgid   "Quit"
+msgstr  "Выйти"
+
+#: lib/solaar/ui/tray.py:279
+msgid   "no receiver"
+msgstr  "нет приёмника"
+
+#: lib/solaar/ui/tray.py:298
+msgid   "no status"
+msgstr  "нет статуса"
+
+#: lib/solaar/ui/window.py:100
+msgid   "Scanning"
+msgstr  "Сканирование"
+
+#: lib/solaar/ui/window.py:133
+msgid   "Battery"
+msgstr  "Батарея"
+
+#: lib/solaar/ui/window.py:136
+msgid   "Wireless Link"
+msgstr  "Беспроводное соединение"
+
+#: lib/solaar/ui/window.py:140
+msgid   "Lighting"
+msgstr  "Подсветка"
+
+#: lib/solaar/ui/window.py:169
+msgid   "Show Technical Details"
+msgstr  "Показать технические детали"
+
+#: lib/solaar/ui/window.py:182
+msgid   "Pair new device"
+msgstr  "Новое сопряженное устройство"
+
+#: lib/solaar/ui/window.py:201
+msgid   "Select a device"
+msgstr  "Выбор устройства"
+
+#: lib/solaar/ui/window.py:498
+msgid   "Path"
+msgstr  "Путь"
+
+#: lib/solaar/ui/window.py:500
+msgid   "USB id"
+msgstr  "Идент. USB"
+
+#: lib/solaar/ui/window.py:503 lib/solaar/ui/window.py:505
+#: lib/solaar/ui/window.py:517 lib/solaar/ui/window.py:519
+msgid   "Serial"
+msgstr  "Серийный ном."
+
+#: lib/solaar/ui/window.py:509
+msgid   "Index"
+msgstr  "Номер"
+
+#: lib/solaar/ui/window.py:510
+msgid   "Wireless PID"
+msgstr  "Беспров. PID"
+
+#: lib/solaar/ui/window.py:512
+msgid   "Protocol"
+msgstr  "Протокол"
+
+#: lib/solaar/ui/window.py:512
+msgid   "Unknown"
+msgstr  "Неизвестен"
+
+#: lib/solaar/ui/window.py:514
+#, python-format
+msgid   "%(rate)d ms (%(rate_hz)dHz)"
+msgstr  "%(rate)d мс (%(rate_hz)dГц)"
+
+#: lib/solaar/ui/window.py:514
+msgid   "Polling rate"
+msgstr  "Част. опроса"
+
+#: lib/solaar/ui/window.py:529
+msgid   "none"
+msgstr  "нет"
+
+#: lib/solaar/ui/window.py:530
+msgid   "Notifications"
+msgstr  "Уведомления"
+
+#: lib/solaar/ui/window.py:566
+msgid   "No device paired."
+msgstr  "Нет сопряженных устройств."
+
+#: lib/solaar/ui/window.py:569
+#, python-format
+msgid   "Up to %(max_count)s device can be paired to this receiver."
+msgid_plural    "Up to %(max_count)s devices can be paired to this receiver."
+msgstr[0]       "До %(max_count)s устройства может быть сопряжено с этим "
+        "приёмником."
+msgstr[1]       "До %(max_count)s устройств может быть сопряжено с этим "
+        "приёмником."
+msgstr[2]       "До %(max_count)s устройств может быть сопряжено с этим "
+        "приёмником."
+
+#: lib/solaar/ui/window.py:571
+msgid   "Only one device can be paired to this receiver."
+msgstr  "Только одно устройство может быть сопряжено с этим приёмником."
+
+#: lib/solaar/ui/window.py:621 lib/solaar/ui/window.py:806
+#, python-format
+msgid   "%(battery_percent)d%%"
+msgstr  "%(battery_percent)d%%"
+
+#: lib/solaar/ui/window.py:624
+msgid   "charging"
+msgstr  "заряжается"
+
+#: lib/solaar/ui/window.py:626
+msgid   "last known"
+msgstr  "последнее известное"
+
+#: lib/solaar/ui/window.py:633
+msgid   "not encrypted"
+msgstr  "не зашифровано"
+
+#: lib/solaar/ui/window.py:635
+msgid   "The wireless link between this device and its receiver is not "
+        "encrypted.\n"
+        "\n"
+        "For pointing devices (mice, trackballs, trackpads), this is a minor "
+        "security issue.\n"
+        "\n"
+        "It is, however, a major security issue for text-input devices "
+        "(keyboards, numpads),\n"
+        "because typed text can be sniffed inconspicuously by 3rd parties "
+        "within range."
+msgstr  "Беспроводное соединение между этим устройством и приёмником не "
+        "зашифровано.\n"
+        "\n"
+        "Для указывающих устройств (мышь, трекбол, трекпад) - это не "
+        "серьёзная уязвимость в безопасности.\n"
+        "\n"
+        "Но, это серьезная уязвимость для устройств ввода текста (клавиатура, "
+        "цифровая клавиатура),\n"
+        "т.к. вводимый текст может быть \"подслушан\"  незаметно кем-то еще в "
+        "радиусе передачи."
+
+#: lib/solaar/ui/window.py:642
+msgid   "encrypted"
+msgstr  "зашифровано"
+
+#: lib/solaar/ui/window.py:644
+msgid   "The wireless link between this device and its receiver is encrypted."
+msgstr  "Беспроводное соединение между этим устройством и приёмником "
+        "зашифровано."
+
+#: lib/solaar/ui/window.py:657
+#, python-format
+msgid   "%(light_level)d lux"
+msgstr  "%(light_level)d люкс"
+
+#: lib/solaar/ui/window.py:804
+#, python-format
+msgid   "%(battery_level)s"
+msgstr  "%(battery_level)s"

--- a/po/solaar.pot
+++ b/po/solaar.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: solaar 0.9.2\n"
         "Report-Msgid-Bugs-To: \n"
-        "POT-Creation-Date: 2013-09-29 16:36+0300\n"
+        "POT-Creation-Date: 2016-12-21 00:13+0200\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,6 +15,7 @@ msgstr  "Project-Id-Version: solaar 0.9.2\n"
         "MIME-Version: 1.0\n"
         "Content-Type: text/plain; charset=UTF-8\n"
         "Content-Transfer-Encoding: 8bit\n"
+        "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
 #: lib/logitech_receiver/i18n.py:38
 msgid   "critical"
@@ -24,7 +25,7 @@ msgstr  ""
 msgid   "empty"
 msgstr  ""
 
-#: lib/logitech_receiver/i18n.py:38 lib/logitech_receiver/i18n.py:41
+#: lib/logitech_receiver/i18n.py:38
 msgid   "full"
 msgstr  ""
 
@@ -38,6 +39,10 @@ msgstr  ""
 
 #: lib/logitech_receiver/i18n.py:41
 msgid   "almost full"
+msgstr  ""
+
+#: lib/logitech_receiver/i18n.py:41
+msgid   "charged"
 msgstr  ""
 
 #: lib/logitech_receiver/i18n.py:41
@@ -80,7 +85,7 @@ msgstr  ""
 msgid   "Bootloader"
 msgstr  ""
 
-#: lib/logitech_receiver/i18n.py:48 lib/solaar/ui/window.py:535
+#: lib/logitech_receiver/i18n.py:48 lib/solaar/ui/window.py:525
 msgid   "Firmware"
 msgstr  ""
 
@@ -93,18 +98,14 @@ msgid   "Other"
 msgstr  ""
 
 #: lib/logitech_receiver/notifications.py:67
-msgid   "closed"
+msgid   "pairing lock is closed"
 msgstr  ""
 
 #: lib/logitech_receiver/notifications.py:67
-msgid   "open"
+msgid   "pairing lock is open"
 msgstr  ""
 
-#: lib/logitech_receiver/notifications.py:67
-msgid   "pairing lock is "
-msgstr  ""
-
-#: lib/logitech_receiver/notifications.py:150 lib/solaar/ui/notify.py:118
+#: lib/logitech_receiver/notifications.py:150 lib/solaar/ui/notify.py:123
 msgid   "unpaired"
 msgstr  ""
 
@@ -112,78 +113,98 @@ msgstr  ""
 msgid   "powered on"
 msgstr  ""
 
-#: lib/logitech_receiver/receiver.py:107 lib/solaar/ui/window.py:622
+#: lib/logitech_receiver/receiver.py:107 lib/solaar/ui/window.py:611
 msgid   "unknown"
 msgstr  ""
 
-#: lib/logitech_receiver/settings_templates.py:77
+#: lib/logitech_receiver/settings_templates.py:119
 msgid   "Smooth Scrolling"
 msgstr  ""
 
-#: lib/logitech_receiver/settings_templates.py:78
+#: lib/logitech_receiver/settings_templates.py:120
 msgid   "High-sensitivity mode for vertical scroll with the wheel."
 msgstr  ""
 
-#: lib/logitech_receiver/settings_templates.py:79
+#: lib/logitech_receiver/settings_templates.py:121
 msgid   "Side Scrolling"
 msgstr  ""
 
-#: lib/logitech_receiver/settings_templates.py:80
+#: lib/logitech_receiver/settings_templates.py:122
 msgid   "When disabled, pushing the wheel sideways sends custom button "
         "events\n"
         "instead of the standard side-scrolling events."
 msgstr  ""
 
-#: lib/logitech_receiver/settings_templates.py:82
+#: lib/logitech_receiver/settings_templates.py:124
 msgid   "Sensitivity (DPI)"
 msgstr  ""
 
-#: lib/logitech_receiver/settings_templates.py:83
+#: lib/logitech_receiver/settings_templates.py:125
 msgid   "Swap Fx function"
 msgstr  ""
 
-#: lib/logitech_receiver/settings_templates.py:84
+#: lib/logitech_receiver/settings_templates.py:126
 msgid   "When set, the F1..F12 keys will activate their special function,\n"
         "and you must hold the FN key to activate their standard function."
 msgstr  ""
 
-#: lib/logitech_receiver/settings_templates.py:87
+#: lib/logitech_receiver/settings_templates.py:129
 msgid   "When unset, the F1..F12 keys will activate their standard function,\n"
         "and you must hold the FN key to activate their special function."
 msgstr  ""
 
-#: lib/logitech_receiver/settings_templates.py:89
+#: lib/logitech_receiver/settings_templates.py:131
 msgid   "Hand Detection"
 msgstr  ""
 
-#: lib/logitech_receiver/settings_templates.py:90
+#: lib/logitech_receiver/settings_templates.py:132
 msgid   "Turn on illumination when the hands hover over the keyboard."
 msgstr  ""
 
-#: lib/logitech_receiver/status.py:98
-msgid   "No paired devices."
+#: lib/logitech_receiver/settings_templates.py:133
+msgid   "Smart Shift"
+msgstr  ""
+
+#: lib/logitech_receiver/settings_templates.py:134
+msgid   "Automatically switch the mouse wheel between ratchet and freespin "
+        "mode.\n"
+        "The mouse wheel is always free at 0, and always locked at 50"
 msgstr  ""
 
 #: lib/logitech_receiver/status.py:99
-msgid   "1 paired device."
+msgid   "No paired devices."
 msgstr  ""
 
-#: lib/logitech_receiver/status.py:100
-msgid   " paired devices."
+#: lib/logitech_receiver/status.py:100 lib/solaar/ui/window.py:566
+#, python-format
+msgid   "%(count)s paired device."
+msgid_plural    "%(count)s paired devices."
+msgstr[0]       ""
+msgstr[1]       ""
+
+#: lib/logitech_receiver/status.py:149
+#, python-format
+msgid   "Battery: %(level)s"
 msgstr  ""
 
-#: lib/logitech_receiver/status.py:149 lib/logitech_receiver/status.py:151
-#: lib/logitech_receiver/status.py:203 lib/logitech_receiver/status.py:205
-#: lib/solaar/ui/window.py:143
-msgid   "Battery"
+#: lib/logitech_receiver/status.py:151
+#, python-format
+msgid   "Battery: %(percent)d%%"
 msgstr  ""
 
-#: lib/logitech_receiver/status.py:162 lib/solaar/ui/window.py:150
-msgid   "Lighting"
+#: lib/logitech_receiver/status.py:162
+#, python-format
+msgid   "Lighting: %(level)s lux"
 msgstr  ""
 
-#: lib/logitech_receiver/status.py:162 lib/solaar/ui/window.py:663
-msgid   "lux"
+#: lib/logitech_receiver/status.py:203
+#, python-format
+msgid   "Battery: %(level)s (%(status)s)"
+msgstr  ""
+
+#: lib/logitech_receiver/status.py:205
+#, python-format
+msgid   "Battery: %(percent)d%% (%(status)s)"
 msgstr  ""
 
 #: lib/solaar/listener.py:95
@@ -210,6 +231,7 @@ msgid   "Unpairing failed"
 msgstr  ""
 
 #: lib/solaar/ui/__init__.py:54
+#, python-brace-format
 msgid   "Failed to unpair %{device} from %{receiver}."
 msgstr  ""
 
@@ -234,29 +256,29 @@ msgstr  ""
 msgid   "Logitech documentation"
 msgstr  ""
 
-#: lib/solaar/ui/action.py:68 lib/solaar/ui/window.py:316
+#: lib/solaar/ui/action.py:68 lib/solaar/ui/window.py:306
 msgid   "About"
 msgstr  ""
 
 #: lib/solaar/ui/action.py:95 lib/solaar/ui/action.py:98
-#: lib/solaar/ui/window.py:203
+#: lib/solaar/ui/window.py:193
 msgid   "Unpair"
 msgstr  ""
 
-#: lib/solaar/ui/config_panel.py:98
+#: lib/solaar/ui/config_panel.py:120
 msgid   "Working"
 msgstr  ""
 
-#: lib/solaar/ui/config_panel.py:101
+#: lib/solaar/ui/config_panel.py:123
 msgid   "Read/write operation failed."
 msgstr  ""
 
-#: lib/solaar/ui/notify.py:120
+#: lib/solaar/ui/notify.py:125
 msgid   "connected"
 msgstr  ""
 
-#: lib/solaar/ui/notify.py:122 lib/solaar/ui/tray.py:290
-#: lib/solaar/ui/tray.py:295 lib/solaar/ui/window.py:653
+#: lib/solaar/ui/notify.py:127 lib/solaar/ui/tray.py:295
+#: lib/solaar/ui/tray.py:300 lib/solaar/ui/window.py:647
 msgid   "offline"
 msgstr  ""
 
@@ -284,7 +306,7 @@ msgid   "No further details are available about the error."
 msgstr  ""
 
 #: lib/solaar/ui/pair_window.py:155
-msgid   "Found a new device"
+msgid   "Found a new device:"
 msgstr  ""
 
 #: lib/solaar/ui/pair_window.py:180
@@ -292,7 +314,8 @@ msgid   "The wireless link is not encrypted"
 msgstr  ""
 
 #: lib/solaar/ui/pair_window.py:197
-msgid   "pair new device"
+#, python-format
+msgid   "%(receiver_name)s: pair new device"
 msgstr  ""
 
 #: lib/solaar/ui/pair_window.py:205
@@ -312,19 +335,121 @@ msgstr  ""
 msgid   "Quit"
 msgstr  ""
 
-#: lib/solaar/ui/tray.py:274
+#: lib/solaar/ui/tray.py:279
 msgid   "no receiver"
 msgstr  ""
 
-#: lib/solaar/ui/tray.py:293
+#: lib/solaar/ui/tray.py:298
 msgid   "no status"
 msgstr  ""
 
-#: lib/solaar/ui/window.py:58
-msgid   "The wireless link between this device and its receiver is encrypted."
+#: lib/solaar/ui/window.py:100
+msgid   "Scanning"
 msgstr  ""
 
-#: lib/solaar/ui/window.py:59
+#: lib/solaar/ui/window.py:133
+msgid   "Battery"
+msgstr  ""
+
+#: lib/solaar/ui/window.py:136
+msgid   "Wireless Link"
+msgstr  ""
+
+#: lib/solaar/ui/window.py:140
+msgid   "Lighting"
+msgstr  ""
+
+#: lib/solaar/ui/window.py:169
+msgid   "Show Technical Details"
+msgstr  ""
+
+#: lib/solaar/ui/window.py:182
+msgid   "Pair new device"
+msgstr  ""
+
+#: lib/solaar/ui/window.py:201
+msgid   "Select a device"
+msgstr  ""
+
+#: lib/solaar/ui/window.py:498
+msgid   "Path"
+msgstr  ""
+
+#: lib/solaar/ui/window.py:500
+msgid   "USB id"
+msgstr  ""
+
+#: lib/solaar/ui/window.py:503 lib/solaar/ui/window.py:505
+#: lib/solaar/ui/window.py:517 lib/solaar/ui/window.py:519
+msgid   "Serial"
+msgstr  ""
+
+#: lib/solaar/ui/window.py:509
+msgid   "Index"
+msgstr  ""
+
+#: lib/solaar/ui/window.py:510
+msgid   "Wireless PID"
+msgstr  ""
+
+#: lib/solaar/ui/window.py:512
+msgid   "Protocol"
+msgstr  ""
+
+#: lib/solaar/ui/window.py:512
+msgid   "Unknown"
+msgstr  ""
+
+#: lib/solaar/ui/window.py:514
+#, python-format
+msgid   "%(rate)d ms (%(rate_hz)dHz)"
+msgstr  ""
+
+#: lib/solaar/ui/window.py:514
+msgid   "Polling rate"
+msgstr  ""
+
+#: lib/solaar/ui/window.py:529
+msgid   "none"
+msgstr  ""
+
+#: lib/solaar/ui/window.py:530
+msgid   "Notifications"
+msgstr  ""
+
+#: lib/solaar/ui/window.py:566
+msgid   "No device paired."
+msgstr  ""
+
+#: lib/solaar/ui/window.py:569
+#, python-format
+msgid   "Up to %(max_count)s device can be paired to this receiver."
+msgid_plural    "Up to %(max_count)s devices can be paired to this receiver."
+msgstr[0]       ""
+msgstr[1]       ""
+
+#: lib/solaar/ui/window.py:571
+msgid   "Only one device can be paired to this receiver."
+msgstr  ""
+
+#: lib/solaar/ui/window.py:621 lib/solaar/ui/window.py:806
+#, python-format
+msgid   "%(battery_percent)d%%"
+msgstr  ""
+
+#: lib/solaar/ui/window.py:624
+msgid   "charging"
+msgstr  ""
+
+#: lib/solaar/ui/window.py:626
+msgid   "last known"
+msgstr  ""
+
+#: lib/solaar/ui/window.py:633
+msgid   "not encrypted"
+msgstr  ""
+
+#: lib/solaar/ui/window.py:635
 msgid   "The wireless link between this device and its receiver is not "
         "encrypted.\n"
         "\n"
@@ -337,92 +462,20 @@ msgid   "The wireless link between this device and its receiver is not "
         "within range."
 msgstr  ""
 
-#: lib/solaar/ui/window.py:67 lib/solaar/ui/window.py:71
-msgid   "No device paired"
-msgstr  ""
-
-#: lib/solaar/ui/window.py:67 lib/solaar/ui/window.py:68
-#, python-format
-msgid   "Up to %d devices can be paired to this receiver"
-msgstr  ""
-
-#: lib/solaar/ui/window.py:68
-msgid   "paired devices"
-msgstr  ""
-
-#: lib/solaar/ui/window.py:72
-msgid   "Only one device can be paired to this receiver"
-msgstr  ""
-
-#: lib/solaar/ui/window.py:110
-msgid   "Scanning"
-msgstr  ""
-
-#: lib/solaar/ui/window.py:146
-msgid   "Wireless Link"
-msgstr  ""
-
-#: lib/solaar/ui/window.py:179
-msgid   "Show Technical Details"
-msgstr  ""
-
-#: lib/solaar/ui/window.py:192
-msgid   "Pair new device"
-msgstr  ""
-
-#: lib/solaar/ui/window.py:211
-msgid   "Select a device"
-msgstr  ""
-
-#: lib/solaar/ui/window.py:508
-msgid   "Path"
-msgstr  ""
-
-#: lib/solaar/ui/window.py:510
-msgid   "USB id"
-msgstr  ""
-
-#: lib/solaar/ui/window.py:513 lib/solaar/ui/window.py:515
-#: lib/solaar/ui/window.py:527 lib/solaar/ui/window.py:529
-msgid   "Serial"
-msgstr  ""
-
-#: lib/solaar/ui/window.py:519
-msgid   "Index"
-msgstr  ""
-
-#: lib/solaar/ui/window.py:520
-msgid   "Wireless PID"
-msgstr  ""
-
-#: lib/solaar/ui/window.py:522
-msgid   "Protocol"
-msgstr  ""
-
-#: lib/solaar/ui/window.py:524
-msgid   "Polling rate"
-msgstr  ""
-
-#: lib/solaar/ui/window.py:539
-msgid   "none"
-msgstr  ""
-
-#: lib/solaar/ui/window.py:540
-msgid   "Notifications"
-msgstr  ""
-
-#: lib/solaar/ui/window.py:635
-msgid   "charging"
-msgstr  ""
-
-#: lib/solaar/ui/window.py:637
-msgid   "last known"
+#: lib/solaar/ui/window.py:642
+msgid   "encrypted"
 msgstr  ""
 
 #: lib/solaar/ui/window.py:644
-msgid   "not encrypted"
+msgid   "The wireless link between this device and its receiver is encrypted."
 msgstr  ""
 
-#: lib/solaar/ui/window.py:648
-msgid   "encrypted"
+#: lib/solaar/ui/window.py:657
+#, python-format
+msgid   "%(light_level)d lux"
+msgstr  ""
+
+#: lib/solaar/ui/window.py:804
+#, python-format
+msgid   "%(battery_level)s"
 msgstr  ""

--- a/share/applications/solaar.desktop
+++ b/share/applications/solaar.desktop
@@ -3,6 +3,7 @@ Name=Solaar
 Comment=Logitech Unifying Receiver peripherals manager
 Comment[fr]=Gestionnaire de périphériques pour les récepteurs Logitech Unifying
 Comment[hr]=Upravitelj Logitechovih uređaja povezanih putem Unifying i Nano prijemnika
+Comment[ru]=Управление приёмником Logitech Unifying Receiver
 Exec=solaar
 Icon=solaar
 StartupNotify=true


### PR DESCRIPTION
I think there is some work needed in Solar for better localization. You need to use [gettext.ngettext](http://docs.python.org/3/library/gettext.html#gettext.ngettext) function for plural forms and do _NOT_ concatenate strings like this:

<pre>
_UNIFYING_RECEIVER_TEXT = (
                gettext.ngettext("No device paired") + '.\n\n<small>' + _("Up to %d devices can be paired to this receiver") + '.</small>',
                '%d ' + _("paired devices") + '\n\n<small>' + _("Up to %d devices can be paired to this receiver") + '.</small>',
</pre>

Instead write something like this:

<pre>
_UNIFYING_RECEIVER_TEXT = (
                _("No device paired.\n\n<small>"Up to %d devices can be paired to this receiver.</small>",
                _("%d paired devices.\n\n<small>Up to %d devices can be paired to this receiver.</small>",
</pre>


See http://techbase.kde.org/Development/Tutorials/Localization/i18n_Mistakes for details.

---

I'll try to do some work on this if I will have free time.

---

Update: Added some example localization fixes. Trying not to break anything. :)
