### PR TITLE
Udev Rule: enable wakeup from suspend on Unifying receivers

### DIFF
--- a/rules.d/42-logitech-unify-permissions.rules
+++ b/rules.d/42-logitech-unify-permissions.rules
@@ -3,9 +3,14 @@
 # Allows non-root users to have raw access the Logitech Unifying USB Receiver
 # device. For development purposes, allowing users to write to the receiver is
 # potentially dangerous (e.g. perform firmware updates).
+# It also enables the resume from suspend through wireless mice and keyboards.
 
 ACTION != "add", GOTO="solaar_end"
-SUBSYSTEM != "hidraw", GOTO="solaar_end"
+SUBSYSTEM == "usb", ENV{DEVTYPE} == "usb_device", GOTO="solaar_check"
+SUBSYSTEM == "hidraw", GOTO="solaar_check"
+GOTO="solaar_end"
+
+LABEL="solaar_check"
 
 # official Unifying receivers
 ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c52b", GOTO="solaar_apply"
@@ -21,6 +26,8 @@ GOTO="solaar_end"
 
 LABEL="solaar_apply"
 
+SUBSYSTEM=="usb", GOTO="solaar_wakeup"
+
 # don't apply to the paired peripherals, just the receivers
 DRIVERS=="logitech-djdevice", GOTO="solaar_end"
 
@@ -31,6 +38,12 @@ TAG+="uaccess", TAG+="udev-acl"
 
 # Grant members of the "plugdev" group access to receiver (useful for SSH users)
 #MODE="0660", GROUP="plugdev"
+
+GOTO="solaar_end"
+
+# Enable wakeup from suspend on the receiver
+LABEL="solaar_wakeup"
+RUN+="/bin/sh -c 'echo enabled > /sys$env{DEVPATH}/power/wakeup'"
 
 LABEL="solaar_end"
 # vim: ft=udevrules


### PR DESCRIPTION
The Unifying receiver does not allow to resume from suspend just pressing a key of the keyboard or a button of the mouse, this is because it's not allowed to wakeup the system (at least in Ubuntu 14.04).

Setting the enabled bit on the wakeup usb sys-node make possible to resume
from suspend when using wireless keyboards and mice.

I've integrated the current udev rule, instead of doing a new one, not to duplicate the devices IDs checks.
