### PR TITLE
Add --hide-icon to start Solaar with a hidden icon

### DIFF
--- a/lib/solaar/gtk.py
+++ b/lib/solaar/gtk.py
@@ -46,6 +46,8 @@ def _parse_arguments():
 							help='unifying receiver to use; the first detected receiver if unspecified. Example: /dev/hidraw2')
 	arg_parser.add_argument('--restart-on-wake-up', action='store_true',
 							help='restart Solaar on sleep wake-up (experimental)')
+	arg_parser.add_argument('--hide-icon', action='store_true',
+							help='hide tray icon, notifications and settings will still get applied')
 	arg_parser.add_argument('-V', '--version', action='version', version='%(prog)s ' + __version__)
 	arg_parser.add_argument('--help-actions', action='store_true',
 							help='print help for the optional actions')
@@ -100,7 +102,10 @@ def main():
 			_upower.watch(listener.ping_all)
 
 		# main UI event loop
-		ui.run_loop(listener.start_all, listener.stop_all)
+		app_args = []
+		if args.hide_icon:
+			app_args.append('--hide-icon')
+		ui.run_loop(listener.start_all, listener.stop_all, app_args)
 	except Exception as e:
 		import sys
 		sys.exit('%s: error: %s' % (NAME.lower(), e))

--- a/lib/solaar/ui/__init__.py
+++ b/lib/solaar/ui/__init__.py
@@ -112,9 +112,14 @@ def _activate(app):
 
 
 def _command_line(app, command_line):
+	args = command_line.get_arguments()
 	if _log.isEnabledFor(_DEBUG):
-		_log.debug("command_line %s", command_line.get_arguments())
+		_log.debug("command_line %s", args)
 
+	if "--hide-icon" in args:
+		tray.set_visibility(False)
+
+	app.activate()
 	return 0
 
 
@@ -134,9 +139,9 @@ def _shutdown(app, shutdown_hook):
 
 
 def run_loop(startup_hook, shutdown_hook, args=None):
-	# from gi.repository.Gio import ApplicationFlags as _ApplicationFlags
+	from gi.repository.Gio import ApplicationFlags as _ApplicationFlags
 	APP_ID = 'io.github.pwr.solaar'
-	application = Gtk.Application.new(APP_ID, 0) # _ApplicationFlags.HANDLES_COMMAND_LINE)
+	application = Gtk.Application.new(APP_ID, _ApplicationFlags.HANDLES_COMMAND_LINE)
 
 	application.connect('startup', _startup, startup_hook)
 	application.connect('command-line', _command_line)

--- a/lib/solaar/ui/tray.py
+++ b/lib/solaar/ui/tray.py
@@ -205,6 +205,13 @@ try:
 			_icon.set_status(AppIndicator3.IndicatorStatus.ATTENTION)
 			GLib.timeout_add(10 * 1000, _icon.set_status, AppIndicator3.IndicatorStatus.ACTIVE)
 
+
+	def set_visibility(visible):
+		if visible:
+			indicator.set_status(AppIndicator3.IndicatorStatus.ACTIVE)
+		else:
+			indicator.set_status(AppIndicator3.IndicatorStatus.PASSIVE)
+
 except ImportError:
 
 	if _log.isEnabledFor(_DEBUG):
@@ -264,6 +271,10 @@ except ImportError:
 		if _icon_before_attention is None:
 			_icon_before_attention = _icon.get_icon_name()
 			GLib.idle_add(_blink, 9)
+
+
+	def set_visibility(visible):
+		_icon.set_visible(visible)
 
 #
 #


### PR DESCRIPTION
The icon is still created, but not displayed. Addresses a request in
https://github.com/pwr/Solaar/issues/84

add_main_option_entries[1](https://wiki.gnome.org/HowDoI/GtkApplication/CommandLine) could be used, but is only supported in
GLib 2.40 and newer which excludes Ubuntu 13.10 Saucy and Debian Wheezy
and earlier.
