### PR TITLE
Add M600 settings and smooth_scroll and side_scroll to FeatureSettings

### DIFF
--- a/docs/devices.md
+++ b/docs/devices.md
@@ -83,7 +83,7 @@ Mice (Unifying):
 | M510             | 1.0   | yes     |       | smooth scrolling                |
 | M515 Couch       | 2.0   | yes     | -     | smooth scrolling                |
 | M525             | 2.0   | yes     | -     | smooth scrolling                |
-| M600 Touch       | 2.0   | yes     |       |                                 |
+| M600 Touch       | 2.0   | yes     |       | smooth scrolling                |
 | M705 Marathon    | 1.0   | yes     | -     | smooth scrolling                |
 | T400 Zone Touch  | 2.0   | yes     |       | smooth scrolling                |
 | T620 Touch       | 2.0   | yes     |       |                                 |
@@ -157,6 +157,7 @@ Mouse-Keyboard combos:
 [K800]: http://logitech.com/product/wireless-illuminated-keyboard-k800
 [K830]: http://logitech.com/product/living-room-keyboard-k830
 [M510]: http://logitech.com/product/wireless-mouse-m510
+[M600]: http://support.logitech.com/en_us/product/touch-mouse-m600
 [M705]: http://logitech.com/product/marathon-mouse-m705
 [P_MX]: http://logitech.com/product/performance-mouse-mx
 [A_MX]: http://logitech.com/product/anywhere-mouse-mx

--- a/docs/devices/m600.txt
+++ b/docs/devices/m600.txt
@@ -1,0 +1,39 @@
+  1: Touch Mouse M600
+     Codename     : M600
+     Kind         : mouse
+     Wireless PID : 401A
+     Protocol     : HID++ 2.0
+     Polling rate : 8 ms (125Hz)
+     Serial number: 84DF19F3
+          Firmware: RQM 34.00.B0019
+        Bootloader: BL  02.00.B0013
+          Hardware: 72
+             Other: 
+     The power switch is located on the base.
+     Supports 22 HID++ 2.0 features:
+         0: ROOT                   {0000}   
+         1: FEATURE SET            {0001}   
+         2: FEATURE INFO           {0002}   
+         3: DEVICE FW VERSION      {0003}   
+         4: DEVICE NAME            {0005}   
+         5: BATTERY STATUS         {1000}   
+         6: WIRELESS DEVICE STATUS {1D4B}   
+         7: unknown:1DF3           {1DF3}   internal, hidden
+         8: REPROG CONTROLS        {1B00}   
+         9: unknown:1F03           {1F03}   internal, hidden
+        10: VERTICAL SCROLLING     {2100}   
+        11: MOUSE POINTER          {2200}   
+        12: DFUCONTROL             {00C0}   
+        13: unknown:1E80           {1E80}   internal, hidden
+        14: TOUCHMOUSE RAW POINTS  {6110}   hidden
+        15: unknown:2101           {2101}   hidden
+        16: LEFT RIGHT SWAP        {2001}   
+        17: unknown:1E00           {1E00}   hidden
+        18: unknown:1F04           {1F04}   internal, hidden
+        19: unknown:18E2           {18E2}   internal, hidden
+        20: HI RES SCROLLING       {2120}   
+        21: unknown:18E3           {18E3}   internal, hidden
+     Has 2 reprogrammable keys:
+         0: LEFT CLICK                 => LeftClick                     mse, reprogrammable
+         1: RIGHT CLICK                => RightClick                    mse, reprogrammable
+     Battery: 80%, discharging.

--- a/lib/logitech_receiver/descriptors.py
+++ b/lib/logitech_receiver/descriptors.py
@@ -239,7 +239,12 @@ _D('Wireless Mouse M510', protocol=1.0, wpid='1025',
 				)
 _D('Couch Mouse M515', protocol=2.0, wpid='4007')
 _D('Wireless Mouse M525', protocol=2.0, wpid='4013')
-_D('Touch Mouse M600', protocol=2.0, wpid='401A')
+_D('Touch Mouse M600', protocol=2.0, wpid='401A',
+				settings=[
+							# _FS.side_scroll(),
+							_FS.smooth_scroll(),
+						],
+		)
 _D('Marathon Mouse M705', protocol=1.0, wpid='101B',
 				registers=(_R.battery_charge, ),
 				settings=[

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -135,6 +135,11 @@ def _feature_smooth_scroll():
 					label=_SMOOTH_SCROLL[1], description=_SMOOTH_SCROLL[2],
 					device_kind=_DK.mouse)
 
+def _feature_side_scroll():
+	return feature_toggle(_SIDE_SCROLL[0], _F.VERTICAL_SCROLLING,
+					label=_SIDE_SCROLL[1], description=_SIDE_SCROLL[2],
+					device_kind=_DK.mouse)
+
 #
 #
 #
@@ -164,7 +169,7 @@ FeatureSettings =  _SETTINGS_LIST(
 				fn_swap=_feature_fn_swap,
 				new_fn_swap=_feature_new_fn_swap,
 				smooth_scroll=_feature_smooth_scroll,
-				side_scroll=None,
+				side_scroll=_feature_side_scroll,
 				dpi=None,
 				hand_detection=None,
 				typing_illumination=None,


### PR DESCRIPTION
I tried to hack together the settings for M600 mouse, mostly ignorant about the correct way to do it - so, maybe there are things wrong with this, I don't know about it but I am eager to learn about it.
It seems as if ```check_feature_settings``` is supposed to extract the features automagically, making this redundant, but if so, then there is something different wrong on that end?

side-scroll is _not_ enabled in the description, as it would cause an ```invalid function``` error and cause the gui to disable all settings, and I did not find the cause yet.

I thought this is a starting point and someone else might have an idea how to progress from here or at least someone would tell me where I went wrong.