### PR TITLE
Add support for MK220 mouse-keyboard combo device.

### DIFF
--- a/docs/devices.md
+++ b/docs/devices.md
@@ -140,6 +140,7 @@ Mouse-Keyboard combos:
 
 | Device           | HID++ | Battery | Other supported features                |
 |------------------|-------|---------|-----------------------------------------|
+| MK220            | 2.0   | yes     |                                         |
 | MK330            |       |         |                                         |
 | MK520            |       |         |                                         |
 | MK550            |       |         |                                         |

--- a/docs/devices/mk220.txt
+++ b/docs/devices/mk220.txt
@@ -1,0 +1,78 @@
+Unifying Receiver
+  Device path  : /dev/hidraw1
+  USB id       : 046d:c52e
+  Serial       : 758596BF
+    Firmware   : 23.01.B0006
+  Has 2 paired device(s) out of a maximum of 2.
+  Notifications: wireless, software present (0x000900)
+
+  1: Wireless Mouse M150
+     Codename     : M150
+     Kind         : mouse
+     Wireless PID : 400C
+     Protocol     : HID++ 2.0
+     Polling rate : 8 ms (125Hz)
+     Serial number: 93850883
+          Firmware: RQM 29.00.B0010
+     The power switch is located on the base.
+     Supports 16 HID++ 2.0 features:
+         0: ROOT                   {0000}   
+         1: FEATURE SET            {0001}   
+         2: DEVICE FW VERSION      {0003}   
+         3: DEVICE NAME            {0005}   
+         4: unknown:1850           {1850}   hidden
+         5: unknown:1860           {1860}   hidden
+         6: BATTERY STATUS         {1000}   
+         7: WIRELESS DEVICE STATUS {1D4B}   
+         8: unknown:1DF3           {1DF3}   hidden
+         9: REPROG CONTROLS        {1B00}   
+        10: unknown:1DF0           {1DF0}   hidden
+        11: unknown:1E00           {1E00}   hidden
+        12: unknown:1E80           {1E80}   hidden
+        13: unknown:1F03           {1F03}   hidden
+        14: VERTICAL SCROLLING     {2100}   
+        15: MOUSE POINTER          {2200}   
+     Has 3 reprogrammable keys:
+         0: LEFT CLICK                 => LeftClick                     mse, reprogrammable
+         1: RIGHT CLICK                => RightClick                    mse, reprogrammable
+         2: MIDDLE BUTTON              => MiddleMouseButton             mse, reprogrammable
+     Battery: 90%, discharging.
+
+  2: Wireless Keyboard K220
+     Codename     : K220
+     Kind         : keyboard
+     Wireless PID : 4005
+     Protocol     : HID++ 2.0
+     Polling rate : 20 ms (50Hz)
+     Serial number: 5BB1D72E
+          Firmware: RQK 37.00.B0011
+     Supports 14 HID++ 2.0 features:
+         0: ROOT                   {0000}   
+         1: FEATURE SET            {0001}   
+         2: FEATURE INFO           {0002}   
+         3: DEVICE FW VERSION      {0003}   
+         4: DEVICE NAME            {0005}   
+         5: BATTERY STATUS         {1000}   
+         6: unknown:1820           {1820}   hidden
+         7: REPROG CONTROLS        {1B00}   
+         8: REPROG CONTROLS V2     {1B01}   
+         9: WIRELESS DEVICE STATUS {1D4B}   
+        10: unknown:1DF0           {1DF0}   hidden
+        11: unknown:1DF3           {1DF3}   hidden
+        12: ENCRYPTION             {4100}   
+        13: KEYBOARD LAYOUT        {4520}   
+     Has 12 reprogrammable keys:
+         0: FN F1                      => Do Nothing One                is FN, reprogrammable
+         1: FN F2                      => Do Nothing One                is FN, reprogrammable
+         2: FN F3                      => Do Nothing One                is FN, reprogrammable
+         3: FN F4                      => Do Nothing One                is FN, reprogrammable
+         4: FN F5                      => Do Nothing One                is FN, reprogrammable
+         5: FN F6                      => Do Nothing One                is FN, reprogrammable
+         6: FN F7                      => Do Nothing One                is FN, reprogrammable
+         7: FN F8                      => Do Nothing One                is FN, reprogrammable
+         8: FN F9                      => Do Nothing One                is FN, reprogrammable
+         9: Mute                       => Mute                          is FN
+        10: Volume Down                => Volume Down                   is FN
+        11: Volume Up                  => Volume Up                     is FN
+     Battery: 90%, discharging.
+

--- a/docs/usb-ids.txt
+++ b/docs/usb-ids.txt
@@ -10,3 +10,4 @@ Nano receiver, Advanced/Unifying ready:
 Nano receiver:
 	046d:c51a		interface: 1		driver: hid-generic
 	046d:c526		interface: 1		driver: hid-generic
+	046d:c52e		interface: 1		driver: hid-generic

--- a/lib/logitech_receiver/base_usb.py
+++ b/lib/logitech_receiver/base_usb.py
@@ -47,6 +47,7 @@ NANO_RECEIVER_C51B        = _nano_receiver(0xc51b)
 NANO_RECEIVER_C521        = _nano_receiver(0xc521)
 NANO_RECEIVER_C525        = _nano_receiver(0xc525)
 NANO_RECEIVER_C526        = _nano_receiver(0xc526)
+NANO_RECEIVER_C52e        = _nano_receiver(0xc52e)
 
 
 del _unifying_receiver, _nano_receiver
@@ -63,4 +64,5 @@ ALL = (
 		NANO_RECEIVER_C521,
 		NANO_RECEIVER_C525,
 		NANO_RECEIVER_C526,
+		NANO_RECEIVER_C52e,
 	)

--- a/packaging/debian/solaar.udev
+++ b/packaging/debian/solaar.udev
@@ -17,6 +17,9 @@ ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c52f", GOTO="solaar_apply"
 # classic Nano receiver -- VX Nano mouse
 ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c526", GOTO="solaar_apply"
 
+# classic Nano receiver -- MK220 mouse and keyboard combo
+ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c52e", GOTO="solaar_apply"
+
 GOTO="solaar_end"
 
 #

--- a/rules.d/42-logitech-unify-permissions.rules
+++ b/rules.d/42-logitech-unify-permissions.rules
@@ -17,6 +17,9 @@ ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c52f", GOTO="solaar_apply"
 # clasic Nano receiver -- VX Nano mouse
 ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c526", GOTO="solaar_apply"
 
+# classic Nano receiver -- MK220 mouse and keyboard combo
+ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c52e", GOTO="solaar_apply"
+
 GOTO="solaar_end"
 
 LABEL="solaar_apply"


### PR DESCRIPTION
The MK220 receiver has usbid 046d:c52e, adding this id as a generic
receiver is enough to show the mouse and keyboard charge status.