### PR TITLE
Adding Logitech mx 1100 cordless laser mouse to discriptors

### DIFF
--- a/docs/devices.md
+++ b/docs/devices.md
@@ -108,6 +108,7 @@ Mice (Nano):
 | M305             | 1.0   | yes     |       |                                 |
 | M310             | 1.0   | yes     |       |                                 |
 | M315             |       | yes     |       |                                 |
+| MX 1100          | 1.0   | yes     | -     | smooth scrolling, side scrolling|
 
 
 Mice (Mini):

--- a/lib/logitech_receiver/descriptors.py
+++ b/lib/logitech_receiver/descriptors.py
@@ -336,6 +336,9 @@ _D('MX Air', codename='MX Air', protocol=1.0, kind=_DK.mouse, wpid=('1007', '100
 _D('MX Revolution', codename='MX Revolution', protocol=1.0, kind=_DK.mouse, wpid=('1008', '100C'),
 				registers=(_R.battery_charge, ),
 				)
+_D('MX 1100 Cordless Laser Mouse', codename='MX 1100', protocol=1.0, wpid='1014',
+                registers=(_R.battery_charge, ),
+                )
 
 # Some exotics...
 

--- a/lib/logitech_receiver/descriptors.py
+++ b/lib/logitech_receiver/descriptors.py
@@ -336,8 +336,12 @@ _D('MX Air', codename='MX Air', protocol=1.0, kind=_DK.mouse, wpid=('1007', '100
 _D('MX Revolution', codename='MX Revolution', protocol=1.0, kind=_DK.mouse, wpid=('1008', '100C'),
 				registers=(_R.battery_charge, ),
 				)
-_D('MX 1100 Cordless Laser Mouse', codename='MX 1100', protocol=1.0, wpid='1014',
+_D('MX 1100 Cordless Laser Mouse', codename='MX 1100', protocol=1.0, kind=_DK.mouse, wpid='1014',
                 registers=(_R.battery_charge, ),
+                settings=[
+							_RS.smooth_scroll(),
+							_RS.side_scroll(),
+						],
                 )
 
 # Some exotics...


### PR DESCRIPTION
Solaar is working with the nano receiver, battery info showing just missing the description about the mouse. This adds the MX 1100 to the list. 