### PR TITLE
Don't open a main window when battery is critical

### DIFF
--- a/lib/solaar/ui/__init__.py
+++ b/lib/solaar/ui/__init__.py
@@ -161,10 +161,10 @@ def _status_changed(device, alert, reason):
 	if alert & ALERT.ATTENTION:
 		tray.attention(reason)
 
-	need_popup = alert & (ALERT.SHOW_WINDOW | ALERT.ATTENTION)
+	need_popup = alert & ALERT.SHOW_WINDOW
 	window.update(device, need_popup)
 
-	if alert & ALERT.NOTIFICATION:
+	if alert & (ALERT.NOTIFICATION | ALERT.ATTENTION):
 		notify.show(device, reason)
 
 


### PR DESCRIPTION
The main window suddenly opening when a battery is critical is very disruptive. It can pop up on all sort of undesirable scenarios, and isn't really a sane behaviour. Rather than catch users of guard, merely show a notification to notify users that the battery is critical.

Fixes #231