### PR TITLE
Fix: "AppIndicator3 was imported without specifying a version first"

### DIFF
--- a/lib/solaar/ui/tray.py
+++ b/lib/solaar/ui/tray.py
@@ -144,7 +144,8 @@ def _scroll(tray_icon, event, direction=None):
 
 
 try:
-	# raise ImportError
+	import gi
+	gi.require_version('AppIndicator3', '0.1')
 	from gi.repository import AppIndicator3
 
 	if _log.isEnabledFor(_DEBUG):


### PR DESCRIPTION
  PyGIWarning: AppIndicator3 was imported without specifying a version
first. Use gi.require_version('AppIndicator3', '0.1') before import to
ensure that the right version gets loaded.