### PR TITLE
add data for m570

### DIFF
--- a/devices.html
+++ b/devices.html
@@ -371,8 +371,8 @@ assign different keys.</p>
 <tbody>
 <tr>
 <td>M570 Trackball</td>
-<td> </td>
-<td> </td>
+<td>1.0</td>
+<td>yes</td>
 <td> </td>
 <td> </td>
 </tr>


### PR DESCRIPTION
1: Wireless Trackball M570
   Codename     : M570
   Kind         : mouse
   Wireless PID : 1028
   Protocol     : HID++ 1.0
   Polling rate : 8 ms
   Serial number: 1D17946D
        Firmware: 26.00.B0003
      Bootloader: 02.06
           Other: 00.01
   The power switch is located on the base.
   Notifications: 0x100000 = battery status.
   Battery: 95%, discharging,
