### PR TITLE
Revert "Fix: "AppIndicator3 was imported without specifying a version first""

### DIFF
--- a/lib/solaar/ui/tray.py
+++ b/lib/solaar/ui/tray.py
@@ -144,7 +144,10 @@ def _scroll(tray_icon, event, direction=None):
 
 
 try:
-	# raise ImportError
+	import gi
+	try:
+		gi.require_version('AppIndicator3', '0.1')
+	except ValueError:
 	from gi.repository import AppIndicator3
 
 	if _log.isEnabledFor(_DEBUG):

--- a/lib/solaar/ui/tray.py
+++ b/lib/solaar/ui/tray.py
@@ -144,8 +144,7 @@ def _scroll(tray_icon, event, direction=None):
 
 
 try:
-	import gi
-	gi.require_version('AppIndicator3', '0.1')
+	# raise ImportError
 	from gi.repository import AppIndicator3
 
 	if _log.isEnabledFor(_DEBUG):


### PR DESCRIPTION
Reverts pwr/Solaar#270

This somehow breaks the Indicator for me. If i want to run solaar i get:
`solaar: error: Namespace AppIndicator3 not available`
If i install gir1.2-appindicator3-0.1 the error goes away and solaar starts again but there is no appindicator anymore..
When trying an older build without this commit the appindicator is still missing. Only if i remove the  gir1.2-appindicator3-0.1 again the appindicator returns..

I am on Ubuntu 16.04 with the Budgie Desktop.
