### PR TITLE
Use HTTPS for github based repositories

### DIFF
--- a/docs/debian.md
+++ b/docs/debian.md
@@ -3,5 +3,5 @@
 To use this repository with your Debian machine, create a file `solaar.list` in
 `/etc/apt/sources.list.d/`, with the following contents:
 
-	deb http://pwr.github.io/Solaar/packages/ ./
-	deb-src http://pwr.github.io/Solaar/packages/ ./
+	deb https://pwr.github.io/Solaar/packages/ ./
+	deb-src https://pwr.github.io/Solaar/packages/ ./


### PR DESCRIPTION
Github Pages support HTTPS natively, so it's better for security to default to that.