### PR TITLE
fixed online bit readout which has to be inverted according to this: …

### DIFF
--- a/lib/logitech_receiver/receiver.py
+++ b/lib/logitech_receiver/receiver.py
@@ -80,7 +80,7 @@ class PairedDevice(object):
 		# 	_log.debug("new PairedDevice(%s, %s, %s)", receiver, number, link_notification)
 
 		if link_notification is not None:
-			self.online = bool(ord(link_notification.data[0:1]) & 0x40)
+			self.online = not bool(ord(link_notification.data[0:1]) & 0x40)
 			self.wpid = _strhex(link_notification.data[2:3] + link_notification.data[1:2])
 			# assert link_notification.address == (0x04 if unifying else 0x03)
 			kind = ord(link_notification.data[0:1]) & 0x0F


### PR DESCRIPTION
I was suffering from a bug described here:
https://github.com/pwr/Solaar/issues/289

I might be totally wrong but I think the reason is quite simple:
The bit in the notification message that indicates if the device is online or not is interpreted inversely. According to this document (which is actualyl written by you?):
https://lekensteyn.nl/files/logitech/logitech_hidpp10_specification_for_Unifying_Receivers.pdf

Means '0' -> device is online and '1' -> device is offline. I think that was wrong in the code so I inverted it. My problem is gone now.