### PR TITLE
UTF-8 file paths error on python 2

### DIFF
--- a/bin/solaar
+++ b/bin/solaar
@@ -26,7 +26,20 @@ def init_paths():
 	import sys
 	import os.path as _path
 
-	prefix = _path.normpath(_path.join(_path.realpath(sys.path[0]), '..'))
+	# Python 2 need conversion from utf-8 filenames
+	# Python 3 might have problems converting back to UTF-8 in case of Unicode surrogates
+	try:
+	    if sys.version_info < (3,):
+	    	decoded_path = sys.path[0].decode(sys.getfilesystemencoding())
+	    else:
+	    	decoded_path = sys.path[0]
+	    	sys.path[0].encode(sys.getfilesystemencoding())
+
+	except UnicodeError:
+	    sys.stderr.write('ERROR: Solaar cannot recognize encoding of filesystem path, this may happen because non UTF-8 characters in the pathname.\n')
+	    sys.exit(1)
+
+	prefix = _path.normpath(_path.join(_path.realpath(decoded_path), '..'))
 	src_lib = _path.join(prefix, 'lib')
 	share_lib = _path.join(prefix, 'share', 'solaar', 'lib')
 	for location in src_lib, share_lib:


### PR DESCRIPTION
Python 2 needs utf-8 decode since it uses 'ascii' decode by default.

Fixes #291 

### **Before:**
```
$ python --version ; echo ; bin/solaar show
Python 2.7.12

Traceback (most recent call last):
  File "bin/solaar", line 42, in <module>
    init_paths()
  File "bin/solaar", line 29, in init_paths
    prefix = _path.normpath(_path.join(_path.realpath(sys.path[0]), '..'))
  File "/usr/lib/python2.7/posixpath.py", line 73, in join
    path += '/' + b
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 44: ordinal not in range(128)
```

```
$ python --version ; echo ; bin/solaar show
Python 3.5.2

solaar: error: Logitech receiver not found
```
### **After:**
```
$ python --version ; echo ; bin/solaar show
Python 2.7.12

solaar: error: Logitech receiver not found
```

```
$ python --version ; echo ; bin/solaar show
Python 3.5.2

solaar: error: Logitech receiver not found
```

Signed-off-by: Josenivaldo Benito Jr <jrbenito@benito.qsl.br>