### PR TITLE
Correct device HID++ version based on user report

### DIFF
--- a/lib/logitech_receiver/descriptors.py
+++ b/lib/logitech_receiver/descriptors.py
@@ -166,7 +166,7 @@ _D('Wireless Touch Keyboard K400', protocol=2.0, wpid=('400E', '4024'),
 							_FS.fn_swap()
 						],
 				)
-_D('Wireless Touch Keyboard K400 Plus', protocol=2.0, wpid='404D',
+_D('Wireless Touch Keyboard K400 Plus', protocol=4.1, wpid='404D',
                                 settings=[
                                                         _FS.new_fn_swap()
                                                 ],


### PR DESCRIPTION
Correct device HID++ version based on user report

@coreaa reported that K400 plus is actually HID++ version 4.1 and not 2.0 as described. Reference: #308

Signed-off-by: Josenivaldo Benito Jr <jrbenito@benito.qsl.br>