### PR TITLE
Add M510 (new version) to descriptors

### DIFF
--- a/docs/devices/M510_HIDppV4.5.txt
+++ b/docs/devices/M510_HIDppV4.5.txt
@@ -30,4 +30,19 @@
         19: unknown:1F03           {1F03}   internal, hidden
         20: LOWRES WHEEL           {2130}   
         21: POINTER SPEED          {2205}   
+     Has 7 reprogrammable keys:
+         0: LEFT CLICK                , default: LeftClick                   => LEFT CLICK                
+             divertable, mse, pos:0, group:1, gmask:1
+         1: RIGHT CLICK               , default: RightClick                  => RIGHT CLICK               
+             divertable, mse, pos:0, group:1, gmask:1
+         2: MIDDLE BUTTON             , default: MiddleMouseButton           => MIDDLE BUTTON             
+             divertable, mse, reprogrammable, pos:0, group:2, gmask:3
+         3: LEFT SCROLL AS AC PAN     , default: HorzScrollLeftSet           => LEFT SCROLL AS AC PAN     
+             divertable, mse, reprogrammable, pos:0, group:2, gmask:3
+         4: RIGHT SCROLL AS AC PAN    , default: HorzScrollRightSet          => RIGHT SCROLL AS AC PAN    
+             divertable, mse, reprogrammable, pos:0, group:2, gmask:3
+         5: BACK AS BUTTON 4          , default: BackEx                      => BACK AS BUTTON 4          
+             divertable, mse, reprogrammable, pos:0, group:2, gmask:3
+         6: FORWARD AS BUTTON 5       , default: BrowserForwardEx            => FORWARD AS BUTTON 5       
+             divertable, mse, reprogrammable, pos:0, group:2, gmask:3
      Battery: 70%, discharging.

--- a/lib/logitech_receiver/descriptors.py
+++ b/lib/logitech_receiver/descriptors.py
@@ -250,6 +250,10 @@ _D('Wireless Mouse M510', protocol=1.0, wpid='1025',
 							_RS.side_scroll(),
 						],
 				)
+_D('Wireless Mouse M510', codename='M510v2', protocol=2.0, wpid='4051',
+				settings=[
+							_FS.lowres_smooth_scroll(),
+				])
 _D('Couch Mouse M515', protocol=2.0, wpid='4007')
 _D('Wireless Mouse M525', protocol=2.0, wpid='4013')
 _D('Touch Mouse M600', protocol=2.0, wpid='401A')


### PR DESCRIPTION
*** Depends on #337

fixes #279

Smooth Scrolling feature is set but as result it diverts events to HID++ instead of HID. As result, since Logitech Kernel Driver does not handle these events, wheel stops to work. This is not Solaar bug.

Pointer Speed works thanks to @doctor64 work.

Signed-off-by: Josenivaldo Benito Jr <jrbenito@benito.qsl.br>