### PR TITLE
Mx anywhere2 v4

### DIFF
--- a/lib/logitech_receiver/descriptors.py
+++ b/lib/logitech_receiver/descriptors.py
@@ -272,7 +272,9 @@ _D('Anywhere Mouse MX', codename='Anywhere MX', protocol=1.0, wpid='1017',
 				)
 _D('Anywhere Mouse MX 2', codename='Anywhere MX 2', protocol=4.5, wpid='404A',
 				settings=[
-							_FS.smooth_scroll(),
+							_FS.hires_smooth_invert(),
+							_FS.hires_smooth_resolution(),
+							_FS.hires_smooth_hid(),
 						],
 				)
 _D('Performance Mouse MX', codename='Performance MX', protocol=1.0, wpid='101A',

--- a/lib/logitech_receiver/hidpp20.py
+++ b/lib/logitech_receiver/hidpp20.py
@@ -457,3 +457,30 @@ def get_mouse_pointer_info(device):
 				'suggest_os_ballistics': suggest_os_ballistics,
 				'suggest_vertical_orientation': suggest_vertical_orientation
 			}
+
+def get_hires_wheel(device):
+	caps = feature_request(device, FEATURE.HIRES_WHEEL, 0x00)
+	mode = feature_request(device, FEATURE.HIRES_WHEEL, 0x10)
+	ratchet = feature_request(device, FEATURE.HIRES_WHEEL, 0x030)
+
+
+	if caps and mode and ratchet:
+		# Parse caps
+		multi, flags = _unpack('!BB', caps[:2])
+
+		has_invert = (flags & 0x08) != 0
+		has_ratchet = (flags & 0x04) != 0
+
+		# Parse mode
+		wheel_mode, reserved = _unpack('!BB', mode[:2])
+
+		target = (wheel_mode & 0x01) != 0
+		res = (wheel_mode & 0x02) != 0
+		inv = (wheel_mode & 0x04) != 0
+
+		# Parse Ratchet switch
+		ratchet_mode, reserved = _unpack('!BB', ratchet[:2])
+
+		ratchet = (ratchet_mode & 0x01) != 0
+
+		return multi, has_invert, has_ratchet, inv, res, target, ratchet

--- a/lib/logitech_receiver/notifications.py
+++ b/lib/logitech_receiver/notifications.py
@@ -283,4 +283,22 @@ def _process_feature_notification(device, status, n, feature):
 		else:
 			_log.warn("%s: unknown FW_VERSION %s", device, n)
 
+	if feature == _F.HIRES_WHEEL:
+		if (n.address == 0x00):
+			if _log.isEnabledFor(_INFO):
+				flags, delta_v = _unpack('>bh', n.data[:3])
+				high_res = (flags & 0x10) != 0
+				periods = flags & 0x0f
+				_log.info("%s: WHEEL: res: %d periods: %d delta V:%-3d", device, high_res, periods, delta_v)
+			return True
+		elif (n.address == 0x10):
+			if _log.isEnabledFor(_INFO):
+				flags = ord(n.data[:1])
+				ratchet = flags & 0x01
+				_log.info("%s: WHEEL: ratchet: %d", device, ratchet)
+			return True
+		else:
+			_log.warn("%s: unknown WHEEL %s", device, n)
+		return True
+
 	_log.warn("%s: unrecognized %s for feature %s (index %02X)", device, n, feature, n.sub_id)

--- a/lib/logitech_receiver/notifications.py
+++ b/lib/logitech_receiver/notifications.py
@@ -274,4 +274,13 @@ def _process_feature_notification(device, status, n, feature):
 			_log.warn("%s: unknown TOUCH MOUSE %s", device, n)
 		return True
 
+	if feature == _F.DEVICE_FW_VERSION:
+		if (n.address == 0x00) and (n.sub_id == 0x02):
+			if _log.isEnabledFor(_INFO):
+				delta_h, delta_v, wheel = _unpack('<xbhb', n.data[:5])
+				_log.info("%s: MOUSE movement: delta H:%-3d delta V:%-3d wheel: %-3d", device, delta_h, delta_v, wheel)
+			return True
+		else:
+			_log.warn("%s: unknown FW_VERSION %s", device, n)
+
 	_log.warn("%s: unrecognized %s for feature %s (index %02X)", device, n, feature, n.sub_id)

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -118,6 +118,12 @@ def feature_range(name, feature, min_value, max_value,
 
 _SMOOTH_SCROLL = ('smooth-scroll', _("Smooth Scrolling"),
 							_("High-sensitivity mode for vertical scroll with the wheel."))
+_HIRES_INV = ('hires-smooth-invert', _("High Resolution Wheel Invert"),
+							_("High-sensitivity wheel invert mode for vertical scroll."))
+_HIRES_RES = ('hires-smooth-resolution', _("Wheel Resolution"),
+							_("High-sensitivity mode for vertical scroll with the wheel."))
+_HIRES_TGT = ('hires-smooth-hid', _("High Resolution HID++ notification"),
+							_("High-sensitivity HID++ notification for the wheel."))
 _SIDE_SCROLL = ('side-scroll', _("Side Scrolling"),
 							_("When disabled, pushing the wheel sideways sends custom button events\n"
 							"instead of the standard side-scrolling events."))
@@ -177,6 +183,30 @@ def _feature_new_fn_swap():
 def _feature_smooth_scroll():
 	return feature_toggle(_SMOOTH_SCROLL[0], _F.HI_RES_SCROLLING,
 					label=_SMOOTH_SCROLL[1], description=_SMOOTH_SCROLL[2],
+					device_kind=_DK.mouse)
+
+def _feature_hires_smooth_invert():
+	return feature_toggle(_HIRES_INV[0], _F.HIRES_WHEEL,
+					read_function_id=0x10,
+					write_function_id=0x20,
+					true_value=0x04, mask=0x04,
+					label=_HIRES_INV[1], description=_HIRES_INV[2],
+					device_kind=_DK.mouse)
+
+def _feature_hires_smooth_resolution():
+	return feature_toggle(_HIRES_RES[0], _F.HIRES_WHEEL,
+					read_function_id=0x10,
+					write_function_id=0x20,
+					true_value=0x02, mask=0x02,
+					label=_HIRES_RES[1], description=_HIRES_RES[2],
+					device_kind=_DK.mouse)
+
+def _feature_hires_smooth_hid():
+	return feature_toggle(_HIRES_TGT[0], _F.HIRES_WHEEL,
+					read_function_id=0x10,
+					write_function_id=0x20,
+					true_value=0x01, mask=0x01,
+					label=_HIRES_TGT[1], description=_HIRES_TGT[2],
 					device_kind=_DK.mouse)
 
 def _feature_smart_shift():
@@ -259,6 +289,9 @@ _SETTINGS_LIST = namedtuple('_SETTINGS_LIST', [
 					'fn_swap',
 					'new_fn_swap',
 					'smooth_scroll',
+					'hires_smooth_invert',
+					'hires_smooth_resolution',
+					'hires_smooth_hid',
 					'side_scroll',
 					'dpi',
 					'hand_detection',
@@ -271,6 +304,9 @@ RegisterSettings = _SETTINGS_LIST(
 				fn_swap=_register_fn_swap,
 				new_fn_swap=None,
 				smooth_scroll=_register_smooth_scroll,
+				hires_smooth_invert=None,
+				hires_smooth_resolution=None,
+				hires_smooth_hid=None,
 				side_scroll=_register_side_scroll,
 				dpi=_register_dpi,
 				hand_detection=_register_hand_detection,
@@ -281,6 +317,9 @@ FeatureSettings =  _SETTINGS_LIST(
 				fn_swap=_feature_fn_swap,
 				new_fn_swap=_feature_new_fn_swap,
 				smooth_scroll=_feature_smooth_scroll,
+				hires_smooth_invert=_feature_hires_smooth_invert,
+				hires_smooth_resolution=_feature_hires_smooth_resolution,
+				hires_smooth_hid=_feature_hires_smooth_hid,
 				side_scroll=None,
 				dpi=_feature_adjustable_dpi,
 				hand_detection=None,
@@ -320,6 +359,9 @@ def check_feature_settings(device, already_known):
 		already_known.append(feature(device))
 
 	check_feature(_SMOOTH_SCROLL[0], _F.HI_RES_SCROLLING)
+	check_feature(_HIRES_INV[0],     _F.HIRES_WHEEL, "hires_smooth_invert")
+	check_feature(_HIRES_RES[0],     _F.HIRES_WHEEL, "hires_smooth_resolution")
+	check_feature(_HIRES_TGT[0],     _F.HIRES_WHEEL, "hires_smooth_hid")
 	check_feature(_FN_SWAP[0],       _F.FN_INVERSION)
 	check_feature(_FN_SWAP[0],       _F.NEW_FN_INVERSION, 'new_fn_swap')
 	check_feature(_DPI[0],           _F.ADJUSTABLE_DPI)

--- a/lib/solaar/cli/show.py
+++ b/lib/solaar/cli/show.py
@@ -93,6 +93,31 @@ def _print_device(dev):
 			flags = 0 if flags is None else ord(flags[1:2])
 			flags = _hidpp20.FEATURE_FLAG.flag_names(flags)
 			print ('        %2d: %-22s {%04X}   %s' % (index, feature, feature, ', '.join(flags)))
+			if feature == _hidpp20.FEATURE.HIRES_WHEEL:
+				wheel = _hidpp20.get_hires_wheel(dev)
+				if wheel:
+					multi, has_invert, has_switch, inv, res, target, ratchet = wheel
+					print("            Multiplier: %s" % multi)
+					if has_invert:
+						print("            Has invert")
+						if inv:
+							print("              Inverse wheel motion")
+						else:
+							print("              Normal wheel motion")
+					if has_switch:
+						print("            Has ratchet switch")
+						if ratchet:
+							print("              Normal wheel mode")
+						else:
+							print("              Free wheel mode")
+					if res:
+						print("            High resolution mode")
+					else:
+						print("            Low resolution mode")
+					if target:
+						print("            HID++ notification")
+					else:
+						print("            HID notification")
 
 	if dev.online and dev.keys:
 		print ('     Has %d reprogrammable keys:' % len(dev.keys))


### PR DESCRIPTION
Add support for controlling and events for the MX Anyware 2 High-res Wheel

The high-res wheel allows setting 3 properties:

    if the wheel will scroll inverted;
    if the wheel will use high-resolution (e. g. will scroll faster);
    if the wheel will send HID++ or HID notifications.

Currently, the Logitech HID Kernel driver doesn't handle HID++ wheel notifications. So, when this mode is set, the scroll won't work on apps. It is possible to see the HID++ messages, though, by enabling solaar debug logs.

With this mouse, mouse movement and wheel HID events, on HID mode are like those:

<pre>
000009159 ms 000008 ms (007961 us EP=83, Dev=6a) >>> 20 03 02 00 00 ff ff ff 00 00 00 00 00 00 00
000009167 ms 000008 ms (007957 us EP=83, Dev=6a) >>> 20 03 02 00 00 00 f0 ff 00 00 00 00 00 00 00
000009175 ms 000008 ms (007905 us EP=83, Dev=6a) >>> 20 03 02 00 00 ff ff ff 00 00 00 00 00 00 00
000009183 ms 000008 ms (007972 us EP=83, Dev=6a) >>> 20 03 02 00 00 00 f0 ff 00 00 00 00 00 00 00
000009191 ms 000008 ms (007940 us EP=83, Dev=6a) >>> 20 03 02 00 00 00 f0 ff 00 00 00 00 00 00 00
000009199 ms 000008 ms (007913 us EP=83, Dev=6a) >>> 20 03 02 00 00 00 f0 ff 00 00 00 00 00 00 00
000009207 ms 000008 ms (077958 us EP=83, Dev=6a) >>> 20 03 02 00 00 ff 0f 00 00 00 00 00 00 00 00
000009285 ms 000078 ms (007967 us EP=83, Dev=6a) >>> 20 03 02 00 00 00 f0 ff 00 00 00 00 00 00 00
000009293 ms 000008 ms (007916 us EP=83, Dev=6a) >>> 20 03 02 00 00 00 f0 ff 00 00 00 00 00 00 00
000009301 ms 000008 ms (615980 us EP=83, Dev=6a) >>> 20 03 02 00 00 00 10 00 00 00 00 00 00 00 00
000009917 ms 000616 ms (007940 us EP=83, Dev=6a) >>> 20 03 02 00 00 00 10 00 00 00 00 00 00 00 00
000009925 ms 000008 ms (007926 us EP=83, Dev=6a) >>> 20 03 02 00 00 01 00 00 00 00 00 00 00 00 00
</pre>

Those packets start with "20" and have "00" for feature request_id (with is supposed to be DEVICE_FW_VERSION).

Ratchet HID events always come from feature 0x2121.

When the mouse is in HID++, wheel events also come from feature 0x2121. 

When called via CLI, solaar show will display the settings for the mouse just after the high-res feature:

        11: HIRES WHEEL            {2121}   
            Multiplier: 8
            Has invert
              Normal wheel motion
            Has ratchet switch
              Free wheel mode
            Low resolution mode
            HID notification

Tested on my MX Anywhere 2 device on both CLI and GUI.