### PR TITLE
Fix solaar start issues

### DIFF
--- a/lib/logitech_receiver/descriptors.py
+++ b/lib/logitech_receiver/descriptors.py
@@ -285,7 +285,6 @@ _D('Anywhere Mouse MX 2', codename='Anywhere MX 2', protocol=4.5, wpid='404A',
 				settings=[
 							_FS.hires_smooth_invert(),
 							_FS.hires_smooth_resolution(),
-							_FS.hires_smooth_hid(),
 						],
 				)
 _D('Performance Mouse MX', codename='Performance MX', protocol=1.0, wpid='101A',

--- a/lib/logitech_receiver/descriptors.py
+++ b/lib/logitech_receiver/descriptors.py
@@ -283,7 +283,9 @@ _D('Anywhere Mouse MX', codename='Anywhere MX', protocol=1.0, wpid='1017',
 				)
 _D('Anywhere Mouse MX 2', codename='Anywhere MX 2', protocol=4.5, wpid='404A',
 				settings=[
-							_FS.smooth_scroll(),
+							_FS.hires_smooth_invert(),
+							_FS.hires_smooth_resolution(),
+							_FS.hires_smooth_hid(),
 						],
 				)
 _D('Performance Mouse MX', codename='Performance MX', protocol=1.0, wpid='101A',

--- a/lib/logitech_receiver/hidpp20.py
+++ b/lib/logitech_receiver/hidpp20.py
@@ -328,13 +328,19 @@ class KeysArray(object):
 					if self.keyversion == 1:
 						self.keys[index] = _ReprogrammableKeyInfo(index, ctrl_id_text, ctrl_task_text, flags)
 					if self.keyversion == 4:
-						mapped_data = feature_request(self.device, FEATURE.REPROG_CONTROLS_V4, 0x20, key&0xff00, key&0xff)
-						if mapped_data:
-							remap_key, remap_flag, remapped = _unpack('!HBH', mapped_data[:5])
-							# if key not mapped map it to itself for display
-							if remapped == 0:
-								remapped = key
-							remapped_text = special_keys.CONTROL[remapped]
+						try:
+							mapped_data = feature_request(self.device, FEATURE.REPROG_CONTROLS_V4, 0x20, key&0xff00, key&0xff)
+							if mapped_data:
+								remap_key, remap_flag, remapped = _unpack('!HBH', mapped_data[:5])
+								# if key not mapped map it to itself for display
+								if remapped == 0:
+									remapped = key
+						except Exception:
+							remapped = key
+							remap_key = key
+							remap_flag = 0
+
+						remapped_text = special_keys.CONTROL[remapped]
 						self.keys[index] = _ReprogrammableKeyInfoV4(index, ctrl_id_text, ctrl_task_text, flags, pos, group, gmask, remapped_text)
 
 			return self.keys[index]

--- a/lib/logitech_receiver/hidpp20.py
+++ b/lib/logitech_receiver/hidpp20.py
@@ -477,3 +477,30 @@ def get_mouse_pointer_info(device):
 				'suggest_os_ballistics': suggest_os_ballistics,
 				'suggest_vertical_orientation': suggest_vertical_orientation
 			}
+
+def get_hires_wheel(device):
+	caps = feature_request(device, FEATURE.HIRES_WHEEL, 0x00)
+	mode = feature_request(device, FEATURE.HIRES_WHEEL, 0x10)
+	ratchet = feature_request(device, FEATURE.HIRES_WHEEL, 0x030)
+
+
+	if caps and mode and ratchet:
+		# Parse caps
+		multi, flags = _unpack('!BB', caps[:2])
+
+		has_invert = (flags & 0x08) != 0
+		has_ratchet = (flags & 0x04) != 0
+
+		# Parse mode
+		wheel_mode, reserved = _unpack('!BB', mode[:2])
+
+		target = (wheel_mode & 0x01) != 0
+		res = (wheel_mode & 0x02) != 0
+		inv = (wheel_mode & 0x04) != 0
+
+		# Parse Ratchet switch
+		ratchet_mode, reserved = _unpack('!BB', ratchet[:2])
+
+		ratchet = (ratchet_mode & 0x01) != 0
+
+		return multi, has_invert, has_ratchet, inv, res, target, ratchet

--- a/lib/logitech_receiver/listener.py
+++ b/lib/logitech_receiver/listener.py
@@ -222,7 +222,8 @@ class EventsListener(_threading.Thread):
 		if self._active:  # and _threading.current_thread() == self:
 			# if _log.isEnabledFor(_DEBUG):
 			# 	_log.debug("queueing unhandled %s", n)
-			self._queued_notifications.put(n)
+			if not self._queued_notifications.full():
+				self._queued_notifications.put(n)
 
 	def __bool__(self):
 		return bool(self._active and self.receiver)

--- a/lib/logitech_receiver/notifications.py
+++ b/lib/logitech_receiver/notifications.py
@@ -275,4 +275,22 @@ def _process_feature_notification(device, status, n, feature):
 			_log.warn("%s: unknown TOUCH MOUSE %s", device, n)
 		return True
 
+	if feature == _F.HIRES_WHEEL:
+		if (n.address == 0x00):
+			if _log.isEnabledFor(_INFO):
+				flags, delta_v = _unpack('>bh', n.data[:3])
+				high_res = (flags & 0x10) != 0
+				periods = flags & 0x0f
+				_log.info("%s: WHEEL: res: %d periods: %d delta V:%-3d", device, high_res, periods, delta_v)
+			return True
+		elif (n.address == 0x10):
+			if _log.isEnabledFor(_INFO):
+				flags = ord(n.data[:1])
+				ratchet = flags & 0x01
+				_log.info("%s: WHEEL: ratchet: %d", device, ratchet)
+			return True
+		else:
+			_log.warn("%s: unknown WHEEL %s", device, n)
+		return True
+
 	_log.warn("%s: unrecognized %s for feature %s (index %02X)", device, n, feature, n.sub_id)

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -118,6 +118,12 @@ def feature_range(name, feature, min_value, max_value,
 
 _SMOOTH_SCROLL = ('smooth-scroll', _("Smooth Scrolling"),
 							_("High-sensitivity mode for vertical scroll with the wheel."))
+_HIRES_INV = ('hires-smooth-invert', _("High Resolution Wheel Invert"),
+							_("High-sensitivity wheel invert mode for vertical scroll."))
+_HIRES_RES = ('hires-smooth-resolution', _("Wheel Resolution"),
+							_("High-sensitivity mode for vertical scroll with the wheel."))
+_HIRES_TGT = ('hires-smooth-hid', _("High Resolution HID++ notification"),
+							_("High-sensitivity HID++ notification for the wheel."))
 _SIDE_SCROLL = ('side-scroll', _("Side Scrolling"),
 							_("When disabled, pushing the wheel sideways sends custom button events\n"
 							"instead of the standard side-scrolling events."))
@@ -183,6 +189,29 @@ def _feature_smooth_scroll():
 def _feature_lowres_smooth_scroll():
 	return feature_toggle(_SMOOTH_SCROLL[0], _F.LOWRES_WHEEL,
 					label=_SMOOTH_SCROLL[1], description=_SMOOTH_SCROLL[2],
+					device_kind=_DK.mouse)
+def _feature_hires_smooth_invert():
+	return feature_toggle(_HIRES_INV[0], _F.HIRES_WHEEL,
+					read_function_id=0x10,
+					write_function_id=0x20,
+					true_value=0x04, mask=0x04,
+					label=_HIRES_INV[1], description=_HIRES_INV[2],
+					device_kind=_DK.mouse)
+
+def _feature_hires_smooth_resolution():
+	return feature_toggle(_HIRES_RES[0], _F.HIRES_WHEEL,
+					read_function_id=0x10,
+					write_function_id=0x20,
+					true_value=0x02, mask=0x02,
+					label=_HIRES_RES[1], description=_HIRES_RES[2],
+					device_kind=_DK.mouse)
+
+def _feature_hires_smooth_hid():
+	return feature_toggle(_HIRES_TGT[0], _F.HIRES_WHEEL,
+					read_function_id=0x10,
+					write_function_id=0x20,
+					true_value=0x01, mask=0x01,
+					label=_HIRES_TGT[1], description=_HIRES_TGT[2],
 					device_kind=_DK.mouse)
 
 def _feature_smart_shift():
@@ -275,6 +304,9 @@ _SETTINGS_LIST = namedtuple('_SETTINGS_LIST', [
 					'new_fn_swap',
 					'smooth_scroll',
 					'lowres_smooth_scroll',
+					'hires_smooth_invert',
+					'hires_smooth_resolution',
+					'hires_smooth_hid',
 					'side_scroll',
 					'dpi',
 					'pointer_speed',
@@ -289,6 +321,9 @@ RegisterSettings = _SETTINGS_LIST(
 				new_fn_swap=None,
 				smooth_scroll=_register_smooth_scroll,
 				lowres_smooth_scroll=None,
+				hires_smooth_invert=None,
+				hires_smooth_resolution=None,
+				hires_smooth_hid=None,
 				side_scroll=_register_side_scroll,
 				dpi=_register_dpi,
 				pointer_speed=None,
@@ -301,6 +336,9 @@ FeatureSettings =  _SETTINGS_LIST(
 				new_fn_swap=_feature_new_fn_swap,
 				smooth_scroll=_feature_smooth_scroll,
 				lowres_smooth_scroll=_feature_lowres_smooth_scroll,
+				hires_smooth_invert=_feature_hires_smooth_invert,
+				hires_smooth_resolution=_feature_hires_smooth_resolution,
+				hires_smooth_hid=_feature_hires_smooth_hid,
 				side_scroll=None,
 				dpi=_feature_adjustable_dpi,
 				pointer_speed=_feature_pointer_speed,
@@ -342,6 +380,9 @@ def check_feature_settings(device, already_known):
 
 	check_feature(_SMOOTH_SCROLL[0], _F.HI_RES_SCROLLING)
 	check_feature(_SMOOTH_SCROLL[0], _F.LOWRES_WHEEL)
+	check_feature(_HIRES_INV[0],     _F.HIRES_WHEEL, "hires_smooth_invert")
+	check_feature(_HIRES_RES[0],     _F.HIRES_WHEEL, "hires_smooth_resolution")
+	check_feature(_HIRES_TGT[0],     _F.HIRES_WHEEL, "hires_smooth_hid")
 	check_feature(_FN_SWAP[0],       _F.FN_INVERSION)
 	check_feature(_FN_SWAP[0],       _F.NEW_FN_INVERSION, 'new_fn_swap')
 	check_feature(_DPI[0],           _F.ADJUSTABLE_DPI)

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -122,8 +122,6 @@ _HIRES_INV = ('hires-smooth-invert', _("High Resolution Wheel Invert"),
 							_("High-sensitivity wheel invert mode for vertical scroll."))
 _HIRES_RES = ('hires-smooth-resolution', _("Wheel Resolution"),
 							_("High-sensitivity mode for vertical scroll with the wheel."))
-_HIRES_TGT = ('hires-smooth-hid', _("High Resolution HID++ notification"),
-							_("High-sensitivity HID++ notification for the wheel."))
 _SIDE_SCROLL = ('side-scroll', _("Side Scrolling"),
 							_("When disabled, pushing the wheel sideways sends custom button events\n"
 							"instead of the standard side-scrolling events."))
@@ -204,14 +202,6 @@ def _feature_hires_smooth_resolution():
 					write_function_id=0x20,
 					true_value=0x02, mask=0x02,
 					label=_HIRES_RES[1], description=_HIRES_RES[2],
-					device_kind=_DK.mouse)
-
-def _feature_hires_smooth_hid():
-	return feature_toggle(_HIRES_TGT[0], _F.HIRES_WHEEL,
-					read_function_id=0x10,
-					write_function_id=0x20,
-					true_value=0x01, mask=0x01,
-					label=_HIRES_TGT[1], description=_HIRES_TGT[2],
 					device_kind=_DK.mouse)
 
 def _feature_smart_shift():
@@ -306,7 +296,6 @@ _SETTINGS_LIST = namedtuple('_SETTINGS_LIST', [
 					'lowres_smooth_scroll',
 					'hires_smooth_invert',
 					'hires_smooth_resolution',
-					'hires_smooth_hid',
 					'side_scroll',
 					'dpi',
 					'pointer_speed',
@@ -323,7 +312,6 @@ RegisterSettings = _SETTINGS_LIST(
 				lowres_smooth_scroll=None,
 				hires_smooth_invert=None,
 				hires_smooth_resolution=None,
-				hires_smooth_hid=None,
 				side_scroll=_register_side_scroll,
 				dpi=_register_dpi,
 				pointer_speed=None,
@@ -338,7 +326,6 @@ FeatureSettings =  _SETTINGS_LIST(
 				lowres_smooth_scroll=_feature_lowres_smooth_scroll,
 				hires_smooth_invert=_feature_hires_smooth_invert,
 				hires_smooth_resolution=_feature_hires_smooth_resolution,
-				hires_smooth_hid=_feature_hires_smooth_hid,
 				side_scroll=None,
 				dpi=_feature_adjustable_dpi,
 				pointer_speed=_feature_pointer_speed,
@@ -382,7 +369,6 @@ def check_feature_settings(device, already_known):
 	check_feature(_SMOOTH_SCROLL[0], _F.LOWRES_WHEEL)
 	check_feature(_HIRES_INV[0],     _F.HIRES_WHEEL, "hires_smooth_invert")
 	check_feature(_HIRES_RES[0],     _F.HIRES_WHEEL, "hires_smooth_resolution")
-	check_feature(_HIRES_TGT[0],     _F.HIRES_WHEEL, "hires_smooth_hid")
 	check_feature(_FN_SWAP[0],       _F.FN_INVERSION)
 	check_feature(_FN_SWAP[0],       _F.NEW_FN_INVERSION, 'new_fn_swap')
 	check_feature(_DPI[0],           _F.ADJUSTABLE_DPI)

--- a/lib/solaar/cli/show.py
+++ b/lib/solaar/cli/show.py
@@ -93,6 +93,31 @@ def _print_device(dev):
 			flags = 0 if flags is None else ord(flags[1:2])
 			flags = _hidpp20.FEATURE_FLAG.flag_names(flags)
 			print ('        %2d: %-22s {%04X}   %s' % (index, feature, feature, ', '.join(flags)))
+			if feature == _hidpp20.FEATURE.HIRES_WHEEL:
+				wheel = _hidpp20.get_hires_wheel(dev)
+				if wheel:
+					multi, has_invert, has_switch, inv, res, target, ratchet = wheel
+					print("            Multiplier: %s" % multi)
+					if has_invert:
+						print("            Has invert")
+						if inv:
+							print("              Inverse wheel motion")
+						else:
+							print("              Normal wheel motion")
+					if has_switch:
+						print("            Has ratchet switch")
+						if ratchet:
+							print("              Normal wheel mode")
+						else:
+							print("              Free wheel mode")
+					if res:
+						print("            High resolution mode")
+					else:
+						print("            Low resolution mode")
+					if target:
+						print("            HID++ notification")
+					else:
+						print("            HID notification")
 
 	if dev.online and dev.keys:
 		print ('     Has %d reprogrammable keys:' % len(dev.keys))

--- a/lib/solaar/listener.py
+++ b/lib/solaar/listener.py
@@ -183,7 +183,9 @@ class ReceiverListener(_listener.EventsListener):
 		# a device notification
 		assert n.devnumber > 0 and n.devnumber <= self.receiver.max_devices
 		already_known = n.devnumber in self.receiver
-		if not already_known and n.sub_id == 0x41:
+
+		if n.sub_id == 0x41:
+			already_known = False
 			dev = self.receiver.register_new_device(n.devnumber, n)
 		else:
 			dev = self.receiver[n.devnumber]

--- a/lib/solaar/ui/notify.py
+++ b/lib/solaar/ui/notify.py
@@ -35,7 +35,16 @@ try:
 	from gi.repository import Notify
 
 	# assumed to be working since the import succeeded
-	available = True
+	# available = True
+
+	# This is not working on Fedora 26. If fails with:
+	# ERROR [MainThread] solaar.ui.notify: showing <Notify.Notification object at 0x7f82c2484640 (NotifyNotification at 0x556fa0fc5a40)>
+	# File "./solaar/lib/solaar/ui/notify.py", line 145, in show
+	#   n.show()
+	# Error: g-io-error-quark: Error calling StartServiceByName for org.freedesktop.Notifications: Timeout was reached (24)
+
+	available = False
+
 except (ValueError, ImportError):
 	available = False
 


### PR DESCRIPTION
Solaar initialization on Fedora has become problematic over time. With Fedora 25, sometimes, I had to start it a few times, until it gets everything right. On Fedora 26, things got a lot worse: most of the time, it just doesn't even report the Unified Receiver. When it reports, it takes a lot of time, as it waits for a timeout from g-io-error-quark.

This patch series contain the fixes needed to make it work. After that, Solaar is smoothly detecting both my mouse and Keyboard every time it starts.

On this series we have:

patch 1 - that's actually a minor fix for solaar CLI and Anywhere Mouse MX 2, in order to prevent an error when calling via command line;

patch 2 is actually a hack: efectively it disables the python Notify extension, with doesn't seem to be working here with Fedora 26. I've no idea about how to properly fix it, but Solaar works just fine without it.

patch 3 solves a race condition at the listener logic that registers a new device. It took me a lot of time to discover the root case, as, at least on my i7core machine, turning debug on is usually enough to solve the race issue.

patch 4 solves another race condition: if Solaar are receiving lots of notifications at the time it starts (for example, if the mouse is moving), it loses the registration events, as the queue size is only 16, and it takes several seconds to register the Anywhere Mouse MX 2 mouse.