### PR TITLE
Minor installation.md edit; gpasswd cmd

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -50,5 +50,5 @@ root user:
    Plugging it again will re-create the device node with the right permissions.
 
 3. Make sure your desktop users are part of the `plugdev` group, by running
-   `gpasswd <desktop username> plugdev`. If these users were not assigned to the
+   `gpasswd -a <desktop username> plugdev`. If these users were not assigned to the
    group before, they must re-login for the changes to take effect.


### PR DESCRIPTION
Add '-a' after gpasswd to add USER to group plugdev.
Per: ➜ gpasswd --help
Usage: gpasswd [option] GROUP

Options:
  -a, --add USER                add USER to GROUP
  -d, --delete USER             remove USER from GROUP
  -h, --help                    display this help message and exit
  -Q, --root CHROOT_DIR         directory to chroot into
  -r, --remove-password         remove the GROUP's password
  -R, --restrict                restrict access to GROUP to its members
  -M, --members USER,...        set the list of members of GROUP
  -A, --administrators ADMIN,...
                                set the list of administrators for GROUP
Except for the -A and -M options, the options cannot be combined.