### PR TITLE
Add MX Master 2S descriptor

### DIFF
--- a/lib/logitech_receiver/descriptors.py
+++ b/lib/logitech_receiver/descriptors.py
@@ -308,6 +308,13 @@ _D('Performance Mouse MX', codename='Performance MX', protocol=1.0, wpid='101A',
 
 _D('Wireless Mouse MX Master', codename='MX Master', protocol=4.5, wpid='4041')
 
+_D('Wireless Mouse MX Master 2S', codename='MX Master 2S', protocol=4.5,wpid='4069',
+				settings=[
+							_FS.hires_smooth_invert(),
+							_FS.hires_smooth_resolution(),
+						],
+				)
+
 _D('G7 Cordless Laser Mouse', codename='G7', protocol=1.0, wpid='1002',
 				registers=(_R.battery_status, ),
 				)


### PR DESCRIPTION
Add descriptor for MX Master 2S to support High Resolution Wheel, correct charge level and DPI configuration