### PR TITLE
Update of the installation instructions for Debian

### DIFF
--- a/docs/debian.md
+++ b/docs/debian.md
@@ -1,3 +1,3 @@
 # Debian repository
 
-Solaar is now part of the [official debian repository](https://packages.debian.org/fr/stretch/solaar-gnome3), to install it on your debian machine, use the following command: `sudo apt install solaar-gnome3`
+Solaar is now part of the [official debian repository](https://packages.debian.org/en/stretch/solaar-gnome3), to install it on your debian machine, use the following command: `sudo apt install solaar-gnome3`

--- a/docs/debian.md
+++ b/docs/debian.md
@@ -1,7 +1,3 @@
 # Debian repository
 
-To use this repository with your Debian machine, create a file `solaar.list` in
-`/etc/apt/sources.list.d/`, with the following contents:
-
-	deb https://pwr.github.io/Solaar/packages/ ./
-	deb-src https://pwr.github.io/Solaar/packages/ ./
+Solaar is now part of the [official debian repository](https://packages.debian.org/fr/stretch/solaar-gnome3), to install it on your debian machine, use the following command: `sudo apt install solaar-gnome3`

--- a/docs/debian.md
+++ b/docs/debian.md
@@ -1,3 +1,3 @@
 # Debian repository
 
-Solaar is now part of the [official debian repository](https://packages.debian.org/en/stretch/solaar-gnome3), to install it on your debian machine, use the following command: `sudo apt install solaar-gnome3`
+Solaar is now part of the [official debian repository](https://packages.debian.org/solaar-gnome3), to install it on your debian machine, use the following command: `sudo apt install solaar-gnome3`


### PR DESCRIPTION
Solaar is available on official Debian repository and the old repo link `https://pwr.github.io/Solaar/packages/` is dead and causes `404  Not Found` error and `The repository 'http://pwr.github.io/Solaar/packages ./ Release' does not have a Release file.` error when doing `apt update` so I updated the installation instructions.