### PR TITLE
Add MX Master settings to descriptors

### DIFF
--- a/lib/logitech_receiver/descriptors.py
+++ b/lib/logitech_receiver/descriptors.py
@@ -316,7 +316,12 @@ _D('Performance Mouse MX', codename='Performance MX', protocol=1.0, wpid='101A',
 						],
 				)
 
-_D('Wireless Mouse MX Master', codename='MX Master', protocol=4.5, wpid='4041')
+_D('Wireless Mouse MX Master', codename='MX Master', protocol=4.5, wpid='4041',
+				settings=[
+							_FS.hires_smooth_invert(),
+							_FS.hires_smooth_resolution(),
+						],
+				)
 
 _D('Wireless Mouse MX Master 2S', codename='MX Master 2S', protocol=4.5,wpid='4069',
 				settings=[


### PR DESCRIPTION
Add the same settings to the logitech MX Master as the one from the MX
Master 2 (scroll wheel DPI, smart scoll sensitivity).

Tested on Ubuntu 18.04