### PR TITLE
Added basic support for Lenovo dongle

### DIFF
--- a/lib/logitech_receiver/base_usb.py
+++ b/lib/logitech_receiver/base_usb.py
@@ -30,6 +30,7 @@ _GENERIC_DRIVER = ('hid-generic', 'generic-usb')
 # each tuple contains (vendor_id, product_id, usb interface number, hid driver)
 _unifying_receiver = lambda product_id: (0x046d, product_id, 2, _UNIFYING_DRIVER)
 _nano_receiver = lambda product_id: (0x046d, product_id, 1, _GENERIC_DRIVER)
+_lenovo_receiver = lambda product_id: (0x17ef, product_id, 1, _GENERIC_DRIVER)
 
 
 # standard Unifying receivers (marked with the orange Unifying logo)
@@ -50,6 +51,7 @@ NANO_RECEIVER_C526        = _nano_receiver(0xc526)
 NANO_RECEIVER_C52e        = _nano_receiver(0xc52e)
 NANO_RECEIVER_C531        = _nano_receiver(0xc531)
 NANO_RECEIVER_C534        = _nano_receiver(0xc534)
+NANO_RECEIVER_6042        = _lenovo_receiver(0x6042)
 
 del _unifying_receiver, _nano_receiver
 
@@ -68,4 +70,5 @@ ALL = (
 		NANO_RECEIVER_C52e,
 		NANO_RECEIVER_C531,
 		NANO_RECEIVER_C534,
+		NANO_RECEIVER_6042,
 	)

--- a/packaging/debian/solaar.udev
+++ b/packaging/debian/solaar.udev
@@ -34,6 +34,9 @@ ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c521", GOTO="solaar_apply"
 ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c525", GOTO="solaar_apply"
 ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c534", GOTO="solaar_apply"
 
+# Lenovo nano receiver
+ATTRS{idVendor}=="17ef", ATTRS{idProduct}=="6042", GOTO="solaar_apply"
+
 GOTO="solaar_end"
 
 #

--- a/rules.d/42-logitech-unify-permissions.rules
+++ b/rules.d/42-logitech-unify-permissions.rules
@@ -34,6 +34,10 @@ ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c521", GOTO="solaar_apply"
 ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c525", GOTO="solaar_apply"
 ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c534", GOTO="solaar_apply"
 
+# Lenovo nano receiver
+ATTRS{idVendor}=="17ef", ATTRS{idProduct}=="6042", GOTO="solaar_apply"
+
+
 GOTO="solaar_end"
 
 LABEL="solaar_apply"


### PR DESCRIPTION
I've added vid:pid of Lenovo dongle and it seems to work just fine.
Lenovo N50 mouse is recognised as M185/M225.
![image](https://user-images.githubusercontent.com/20999816/56137704-b3092e80-5f95-11e9-9fb3-bb4baeb8f259.png)
```shell
$ solaar show
Unifying Receiver
  Device path  : /dev/hidraw1
  USB id       : 046d:6042
  Serial       : F33D96C3
    Firmware   : 22.11.B0007
  Has 1 paired device(s) out of a maximum of 1.
  Notifications: wireless, software present (0x000900)

  1: Wireless Mouse M185/M225
     Codename     : M185/M225
     Kind         : mouse
     Wireless PID : 4029
     Protocol     : HID++ 2.0
     Polling rate : 8 ms (125Hz)
     Serial number: 0320E001
          Firmware: RQM 27.02.B0028
     The power switch is located on the base.
     Supports 13 HID++ 2.0 features:
         0: ROOT                   {0000}   
         1: FEATURE SET            {0001}   
         2: DEVICE FW VERSION      {0003}   
         3: DEVICE NAME            {0005}   
         4: BATTERY STATUS         {1000}   
         5: WIRELESS DEVICE STATUS {1D4B}   
         6: unknown:1DF3           {1DF3}   hidden
         7: REPROG CONTROLS        {1B00}   
         8: unknown:1DF0           {1DF0}   hidden
         9: unknown:1F03           {1F03}   hidden
        10: VERTICAL SCROLLING     {2100}   
        11: HI RES SCROLLING       {2120}   
        12: MOUSE POINTER          {2200}   
     Has 3 reprogrammable keys:
         0: LEFT CLICK                 => LeftClick                     mse, reprogrammable
         1: RIGHT CLICK                => RightClick                    mse, reprogrammable
         2: MIDDLE BUTTON              => MiddleMouseButton             mse, reprogrammable
     Battery: 90%, discharging.
```
```shell
$ lsusb -d 0x17ef: -v
Bus 002 Device 046: ID 17ef:6042 Lenovo 
Device Descriptor:
  bLength                18
  bDescriptorType         1
  bcdUSB               2.00
  bDeviceClass            0 
  bDeviceSubClass         0 
  bDeviceProtocol         0 
  bMaxPacketSize0         8
  idVendor           0x17ef Lenovo
  idProduct          0x6042 
  bcdDevice           22.11
  iManufacturer           1 Lenovo
  iProduct                2 USB Receiver
  iSerial                 0 
  bNumConfigurations      1
  Configuration Descriptor:
    bLength                 9
    bDescriptorType         2
    wTotalLength       0x003b
    bNumInterfaces          2
    bConfigurationValue     1
    iConfiguration          4 RQR22.11_B0007
    bmAttributes         0xa0
      (Bus Powered)
      Remote Wakeup
    MaxPower               98mA
    Interface Descriptor:
      bLength                 9
      bDescriptorType         4
      bInterfaceNumber        0
      bAlternateSetting       0
      bNumEndpoints           1
      bInterfaceClass         3 Human Interface Device
      bInterfaceSubClass      1 Boot Interface Subclass
      bInterfaceProtocol      2 Mouse
      iInterface              0 
        HID Device Descriptor:
          bLength                 9
          bDescriptorType        33
          bcdHID               1.11
          bCountryCode            0 Not supported
          bNumDescriptors         1
          bDescriptorType        34 Report
          wDescriptorLength      67
         Report Descriptors: 
           ** UNAVAILABLE **
      Endpoint Descriptor:
        bLength                 7
        bDescriptorType         5
        bEndpointAddress     0x81  EP 1 IN
        bmAttributes            3
          Transfer Type            Interrupt
          Synch Type               None
          Usage Type               Data
        wMaxPacketSize     0x0008  1x 8 bytes
        bInterval               2
    Interface Descriptor:
      bLength                 9
      bDescriptorType         4
      bInterfaceNumber        1
      bAlternateSetting       0
      bNumEndpoints           1
      bInterfaceClass         3 Human Interface Device
      bInterfaceSubClass      0 
      bInterfaceProtocol      0 
      iInterface              0 
        HID Device Descriptor:
          bLength                 9
          bDescriptorType        33
          bcdHID               1.11
          bCountryCode            0 Not supported
          bNumDescriptors         1
          bDescriptorType        34 Report
          wDescriptorLength      79
         Report Descriptors: 
           ** UNAVAILABLE **
      Endpoint Descriptor:
        bLength                 7
        bDescriptorType         5
        bEndpointAddress     0x82  EP 2 IN
        bmAttributes            3
          Transfer Type            Interrupt
          Synch Type               None
          Usage Type               Data
        wMaxPacketSize     0x0014  1x 20 bytes
        bInterval               2
can't get device qualifier: Resource temporarily unavailable
can't get debug descriptor: Resource temporarily unavailable
Device Status:     0x0000
  (Bus Powered)
```
https://download.lenovo.com/consumer/options/lenovo_n50_wireless_optical_mouse.pdf