### PR TITLE
Fix UnicodeDecodeError with ngettext and python2

### DIFF
--- a/lib/logitech_receiver/i18n.py
+++ b/lib/logitech_receiver/i18n.py
@@ -27,8 +27,10 @@ import gettext as _gettext
 try:
 	unicode
 	_ = lambda x: _gettext.gettext(x).decode('UTF-8')
+	ngettext = lambda *x: _gettext.ngettext(*x).decode('UTF-8')
 except:
 	_ = _gettext.gettext
+	ngettext = _gettext.ngettext
 
 
 # A few common strings, not always accessible as such in the code.

--- a/lib/logitech_receiver/status.py
+++ b/lib/logitech_receiver/status.py
@@ -26,8 +26,7 @@ _log = getLogger(__name__)
 del getLogger
 
 
-from .i18n import _
-from gettext import ngettext
+from .i18n import _, ngettext
 from .common import NamedInts as _NamedInts, NamedInt as _NamedInt
 from . import hidpp10 as _hidpp10
 from . import hidpp20 as _hidpp20

--- a/lib/solaar/i18n.py
+++ b/lib/solaar/i18n.py
@@ -60,5 +60,7 @@ _gettext.install(_LOCALE_DOMAIN)
 try:
 	unicode
 	_ = lambda x: _gettext.gettext(x).decode('UTF-8')
+	ngettext = lambda *x: _gettext.ngettext(*x).decode('UTF-8')
 except:
 	_ = _gettext.gettext
+	ngettext = _gettext.ngettext

--- a/lib/solaar/ui/window.py
+++ b/lib/solaar/ui/window.py
@@ -26,10 +26,8 @@ del getLogger
 from gi.repository import Gtk, Gdk, GLib
 from gi.repository.GObject import TYPE_PYOBJECT
 
-
 from solaar import NAME
-from solaar.i18n import _
-from gettext import ngettext
+from solaar.i18n import _, ngettext
 # from solaar import __version__ as VERSION
 from solaar.ui import ui_async as _ui_async
 from logitech_receiver import hidpp10 as _hidpp10


### PR DESCRIPTION
Similar to [what's done for `gettext`](https://github.com/pwr/Solaar/blob/0.9.2/lib/solaar/i18n.py#L62) but for `ngettext`.

Without this change,  errors like the following occur with the French locale (and maybe others) using python2:

```
# ./venv/bin/python bin/solaar
Traceback (most recent call last):
  File "/home/patrick/workspaces/Solaar/lib/solaar/ui/window.py", line 382, in _device_selected
    _update_info_panel(device, full=True)
  File "/home/patrick/workspaces/Solaar/lib/solaar/ui/window.py", line 697, in _update_info_panel
    _update_receiver_panel(device, _info._receiver, _info._buttons, full)
  File "/home/patrick/workspaces/Solaar/lib/solaar/ui/window.py", line 574, in _update_receiver_panel
    paired_text += '\n\n<small>%s</small>' % ngettext('Up to %(max_count)s device can be paired to this receiver.', 'Up to %(max_count)s devices can be paired to this receiver.', receiver.max_devices) % { 'max_count': receiver.max_devices }
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 6: ordinal not in range(128)
```